### PR TITLE
Improving TCPClient handling (multithreaded, disposal)

### DIFF
--- a/src/PFire.Core/PFireServer.cs
+++ b/src/PFire.Core/PFireServer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
+using PFire.Core.Protocol.Interfaces;
 using PFire.Core.Protocol.Messages;
 using PFire.Core.Protocol.Messages.Outbound;
 using PFire.Core.Session;
@@ -26,7 +27,7 @@ namespace PFire.Core
             
             _clientManager = new XFileClientManager();
 
-            _server = new TcpServer(endPoint ?? new IPEndPoint(IPAddress.Any, 25999));
+            _server = new TcpServer(endPoint ?? new IPEndPoint(IPAddress.Any, 25999), _clientManager);
             _server.OnReceive += HandleRequest;
             _server.OnConnection += HandleNewConnection;
             _server.OnDisconnection += OnDisconnection;

--- a/src/PFire.Core/PFireServer.cs
+++ b/src/PFire.Core/PFireServer.cs
@@ -1,29 +1,30 @@
-﻿﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net;
-using PFire.Protocol.Messages;
-using System.Diagnostics;
-using PFire.Session;
+﻿using PFire.Core.Protocol.Interfaces;
+using PFire.Core.Session;
 using PFire.Database;
+using PFire.Protocol.Messages;
 using PFire.Protocol.Messages.Outbound;
-using System.Reflection;
+using PFire.Session;
+using System;
+using System.Net;
 
 namespace PFire
 {
-    public class PFireServer
+    public sealed class PFireServer
     {
         public PFireDatabase Database { get; }
 
         private readonly TcpServer _server;
-        private readonly Dictionary<Guid, XFireClient> _sessions;
+
+
+        private readonly IXFireClientManager _clientManager;
 
         public PFireServer(string baseDirectory, IPEndPoint endPoint = null)
         {
             
             Database = new PFireDatabase(baseDirectory);
-            _sessions = new Dictionary<Guid, XFireClient>();
+            
+            _clientManager = new XFileClientManager();
+
             _server = new TcpServer(endPoint ?? new IPEndPoint(IPAddress.Any, 25999));
             _server.OnReceive += HandleRequest;
             _server.OnConnection += HandleNewConnection;
@@ -69,46 +70,23 @@ namespace PFire
 
         public XFireClient GetSession(Guid sessionId)
         {
-            return _sessions[sessionId];
+            return _clientManager.GetSession(sessionId);
         }
 
         public XFireClient GetSession(User user)
         {
-            var keyValuePair = _sessions.ToList().FirstOrDefault(a => a.Value.User == user);
-            if (!keyValuePair.Equals(default(KeyValuePair<Guid, XFireClient>)))
-            {
-                return keyValuePair.Value;
-            }
-            return null;
+            return _clientManager.GetSession(user);
+            
         }
 
         private void AddSession(XFireClient session)
         {
-            if (_sessions.ContainsKey(session.SessionId))
-            {
-                Debug.WriteLine("Tried to add a user with session id {0} that already existed", "WARN", session.SessionId);
-                return;
-            }
-            _sessions.Add(session.SessionId, session);
+            _clientManager.AddSession(session);
         }
 
         public void RemoveSession(XFireClient session)
         {
-            RemoveSession(session.SessionId);
-        }
-
-        private void RemoveSession(Guid sessionId)
-        {
-            _sessions.Remove(sessionId);
-        }
-
-        public void RemoveSession(User user)
-        {
-            var keyValuePair = _sessions.ToList().FirstOrDefault(a => a.Value.User == user);
-            if (!keyValuePair.Equals(default(KeyValuePair<Guid, XFireClient>)))
-            {
-                _sessions.Remove(keyValuePair.Key);
-            }
+            _clientManager.RemoveSession(session);
         }
     }
 }

--- a/src/PFire.Core/PFireServer.cs
+++ b/src/PFire.Core/PFireServer.cs
@@ -7,7 +7,7 @@ using PFire.Session;
 using System;
 using System.Net;
 
-namespace PFire
+namespace PFire.Core
 {
     public sealed class PFireServer
     {

--- a/src/PFire.Core/Protocol/Interfaces/IXFireClientManager.cs
+++ b/src/PFire.Core/Protocol/Interfaces/IXFireClientManager.cs
@@ -1,0 +1,18 @@
+﻿using PFire.Database;
+using PFire.Session;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PFire.Core.Protocol.Interfaces
+{
+    internal interface IXFireClientManager
+    {
+        XFireClient GetSession(Guid sessionId);
+        XFireClient GetSession(User user);
+        void AddSession(XFireClient session);
+        void RemoveSession(XFireClient session);
+    }
+}

--- a/src/PFire.Core/Protocol/Interfaces/IXFireClientManager.cs
+++ b/src/PFire.Core/Protocol/Interfaces/IXFireClientManager.cs
@@ -1,14 +1,10 @@
-﻿using PFire.Database;
-using PFire.Session;
+﻿using PFire.Core.Session;
+using PFire.Infrastructure.Database;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace PFire.Core.Protocol.Interfaces
 {
-    internal interface IXFireClientManager
+    public interface IXFireClientManager
     {
         XFireClient GetSession(Guid sessionId);
         XFireClient GetSession(User user);

--- a/src/PFire.Core/Protocol/Messages/Inbound/LoginRequest.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/LoginRequest.cs
@@ -33,12 +33,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
             }
 
             // Remove any older sessions from this user (duplicate logins)
-            var otherSession = context.Server.GetSession(user);
-            if (otherSession != null)
-            {
-                context.Server.RemoveSession(otherSession);
-                otherSession.TcpClient.Close();
-            }
+            context.RemoveDuplicatedSessions(user);
 
             context.User = user;
 

--- a/src/PFire.Core/Protocol/Messages/Outbound/LoginSuccess.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/LoginSuccess.cs
@@ -67,7 +67,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
             Nickname = String.IsNullOrEmpty(context.User.Nickname) ? context.User.Username : context.User.Nickname;
             MinRect = 1;
             MaxRect = 164867;
-            var ipAddress = StripPortFromIPAddress(context.TcpClient.Client.RemoteEndPoint.ToString());
+            var ipAddress = StripPortFromIPAddress(context.RemoteEndPoint.ToString());
             PublicIp = BitConverter.ToInt32(IPAddress.Parse(ipAddress).GetAddressBytes(), 0);
             Salt = context.Salt;
             Reason = "Mq_P8Ad3aMEUvFinw0ceu6FITnZTWXxg46XU8xHW";

--- a/src/PFire.Core/Protocol/Messages/XFireMessage.cs
+++ b/src/PFire.Core/Protocol/Messages/XFireMessage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using PFire.Core.Session;
+using PFire.Core.Util;
 
 namespace PFire.Core.Protocol.Messages
 {
@@ -17,10 +18,7 @@ namespace PFire.Core.Protocol.Messages
         public virtual void Process(XFireClient client)
         {
             // base implementation is to do nothing
-            var oldColor = Console.ForegroundColor;
-            Console.ForegroundColor = ConsoleColor.Magenta;
-            Console.WriteLine($" *** Unimplemented processing for message type {MessageTypeId}");
-            Console.ForegroundColor = oldColor;
+            ConsoleLogger.Log($" *** Unimplemented processing for message type {MessageTypeId}", ConsoleColor.Magenta);
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/XFireMessage.cs
+++ b/src/PFire.Core/Protocol/Messages/XFireMessage.cs
@@ -17,7 +17,7 @@ namespace PFire.Core.Protocol.Messages
 
         public virtual void Process(XFireClient client)
         {
-            // base implmenetation is to do nothing
+            // base implementation is to do nothing
             var oldColor = Console.ForegroundColor;
             Console.ForegroundColor = ConsoleColor.Magenta;
             Console.WriteLine($" *** Unimplemented processing for message type {MessageTypeId}");

--- a/src/PFire.Core/Protocol/Messages/XFireMessage.cs
+++ b/src/PFire.Core/Protocol/Messages/XFireMessage.cs
@@ -18,7 +18,10 @@ namespace PFire.Core.Protocol.Messages
         public virtual void Process(XFireClient client)
         {
             // base implmenetation is to do nothing
+            var oldColor = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Magenta;
             Console.WriteLine($" *** Unimplemented processing for message type {MessageTypeId}");
+            Console.ForegroundColor = oldColor;
         }
     }
 }

--- a/src/PFire.Core/Session/XFileClientManager.cs
+++ b/src/PFire.Core/Session/XFileClientManager.cs
@@ -50,7 +50,7 @@ namespace PFire.Core.Session
             XFireClient currentSesson;
             if (_sessions.TryRemove(sessionId, out currentSesson))
             {
-                currentSesson.DisconnectAndStop();
+                currentSesson.Disconnect();
                 currentSesson.Dispose();
             }
         }

--- a/src/PFire.Core/Session/XFileClientManager.cs
+++ b/src/PFire.Core/Session/XFileClientManager.cs
@@ -1,0 +1,65 @@
+﻿using PFire.Core.Protocol.Interfaces;
+using PFire.Database;
+using PFire.Session;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PFire.Core.Session
+{
+    internal sealed class XFileClientManager : IXFireClientManager
+    {
+        // the Dictionary<> is thread safe when read, but not when modified
+        private readonly Dictionary<Guid, XFireClient> _sessions;
+        private readonly  object _lock;
+        public XFileClientManager()
+        {
+            _sessions = new Dictionary<Guid, XFireClient>();
+            _lock = new object();
+        }
+
+        public void AddSession(XFireClient session)
+        {
+            if (_sessions.ContainsKey(session.SessionId))
+            {
+                Console.WriteLine("Tried to add a user with session id {0} that already existed", "WARN", session.SessionId);
+                return;
+            }
+
+            lock (_lock)
+            {
+                _sessions.Add(session.SessionId, session);
+            }
+        }
+
+        public XFireClient GetSession(Guid sessionId)
+        {
+            return _sessions[sessionId];
+        }
+
+        public XFireClient GetSession(User user)
+        {
+            var keyValuePair = _sessions.ToList().FirstOrDefault(a => a.Value.User == user);
+
+            if (!keyValuePair.Equals(default(KeyValuePair<Guid, XFireClient>)))
+            {
+                return keyValuePair.Value;
+            }
+
+            return null;
+        }
+
+        public void RemoveSession(XFireClient session)
+        {
+            RemoveSession(session.SessionId);
+        }
+
+        public void RemoveSession(Guid sessionId)
+        {
+            lock (_lock)
+            {
+                _sessions.Remove(sessionId);
+            }
+        }
+    }
+}

--- a/src/PFire.Core/Session/XFileClientManager.cs
+++ b/src/PFire.Core/Session/XFileClientManager.cs
@@ -1,6 +1,5 @@
 ﻿using PFire.Core.Protocol.Interfaces;
-using PFire.Database;
-using PFire.Session;
+using PFire.Infrastructure.Database;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -18,7 +17,7 @@ namespace PFire.Core.Session
 
         public void AddSession(XFireClient session)
         {
-            if (!_sessions.TryAdd(session.SessionId, session);)
+            if (!_sessions.TryAdd(session.SessionId, session))
             {
                 Console.WriteLine("Tried to add a user with session id {0} that already existed", "WARN", session.SessionId);
             }
@@ -51,6 +50,7 @@ namespace PFire.Core.Session
             XFireClient currentSesson;
             if (_sessions.TryRemove(sessionId, out currentSesson))
             {
+                currentSesson.DisconnectAndStop();
                 currentSesson.Dispose();
             }
         }

--- a/src/PFire.Core/Session/XFireClient.cs
+++ b/src/PFire.Core/Session/XFireClient.cs
@@ -5,6 +5,10 @@ using PFire.Protocol;
 using System;
 using System.IO;
 using System.Net.Sockets;
+using PFire.Database;
+using PFire.Core.Protocol;
+using PFire.Core.Protocol.Messages;
+using PFire.Infrastructure.Database;
 using System.Threading;
 
 namespace PFire.Session

--- a/src/PFire.Core/Session/XFireClient.cs
+++ b/src/PFire.Core/Session/XFireClient.cs
@@ -9,10 +9,11 @@ using PFire.Protocol.Messages;
 using System.Net.Sockets;
 using PFire.Database;
 using PFire.Core.Protocol.Messages;
+using PFire.Core.Util;
 
 namespace PFire.Session
 {
-    public class XFireClient
+    public sealed class XFireClient : Disposable
     {
         public PFireServer Server { get; set; }
 
@@ -21,12 +22,13 @@ namespace PFire.Session
         public bool Initialized { get; private set; }
         public string Salt { get; private set; }
         public Guid SessionId { get; private set; }
+
         public TcpClient TcpClient { get; private set; }
 
         public XFireClient(TcpClient tcpClient)
         {
             TcpClient = tcpClient;
-            
+
             // TODO: be able to use unique salts
             Salt = "4dc383ea21bf4bca83ea5040cb10da62";//Guid.NewGuid().ToString().Replace("-", string.Empty);
             SessionId = Guid.NewGuid();

--- a/src/PFire.Core/Util/ConsoleLogger.cs
+++ b/src/PFire.Core/Util/ConsoleLogger.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace PFire.Core.Util
+{
+    public static class ConsoleLogger
+    {
+        public static void Log(string message, ConsoleColor color = ConsoleColor.White)
+        {
+            var oldColor = Console.ForegroundColor;
+            Console.ForegroundColor = color;
+            Console.WriteLine(message);
+            Console.ForegroundColor = oldColor;
+        }
+    }
+}

--- a/src/PFire.Core/Util/Disposable.cs
+++ b/src/PFire.Core/Util/Disposable.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace PFire.Core.Util
+{
+    public abstract class Disposable : IDisposable
+    {
+        protected bool Disposed;
+        protected bool IsDisposing;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!Disposed)
+            {
+                if (disposing)
+                {
+                    try
+                    {
+                        IsDisposing = true;
+                        DisposeManagedResources();
+                    }
+                    finally
+                    {
+                        IsDisposing = false;
+                    }
+                }
+
+                Disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void DisposeManagedResources() { }
+    }
+}

--- a/src/PFire.WindowsService/Program.cs
+++ b/src/PFire.WindowsService/Program.cs
@@ -5,11 +5,12 @@ using Topshelf;
 
 namespace PFire.WindowsService
 {
-    class Program
+    static class Program
     {
         public static void Main(string[] args)
         {
             var baseDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
             HostFactory.Run(x =>
             {
                 x.Service<PFireServer>(s =>
@@ -18,8 +19,8 @@ namespace PFire.WindowsService
                     s.WhenStarted(pf => pf.Start());
                     s.WhenStopped(pf => pf.Stop());
                 });
-                x.RunAsLocalSystem();
 
+                x.RunAsLocalSystem();
                 x.SetDescription("Emulated XFire Server");
                 x.SetDisplayName("PFire Server");
                 x.SetServiceName("PFireServer");


### PR DESCRIPTION
The server has an issue ( #6 ) where it no longer accepts new connections after a while. Currently, there is no disposal processing for TCPClients, and the server creates them and then waits for them to talk to it. If nothing is ever received, that client remains open.

What was done

- created a session manager, to clean up the TCP server code.
- moved client processing out of server to the client object
- moved the reading of data from the client to its own thread. This allows lifetime tracking
- handled disposal better.. The client can just disappear, in which is required some special case handling.

I don't believe that we need async reads on the TCP client as we are now running TCP client in its own thread, managed by the thread pool 
