### PR TITLE
Fix UserInsert - It returns now the correct user instead of always the first one.

### DIFF
--- a/src/PFire.Infrastructure/Database/PFireDatabase.cs
+++ b/src/PFire.Infrastructure/Database/PFireDatabase.cs
@@ -22,8 +22,9 @@ namespace PFire.Infrastructure.Database
 
         public User InsertUser(string username, string password, string salt)
         {
-            var id = Insert(User.New(username, password, salt));
-            return QueryUser(id);
+            var newUser = User.New(username, password, salt);
+            Insert(newUser);
+            return QueryUser(newUser.UserId);
         }
 
         public void InsertMutualFriend(User user1, User user2)


### PR DESCRIPTION
SQLiteConnection.Insert returns the number of affected rows (always 1 for an insert which it then searches for, always returning the first user). It actually updates the entity passed in with the new primary key ID. Replace that entire method with the following. 

This one is fixed now. 