### PR TITLE
make all database / session interactions `async`

### DIFF
--- a/src/PFire.Core/ITcpServer.cs
+++ b/src/PFire.Core/ITcpServer.cs
@@ -6,11 +6,11 @@ namespace PFire.Core
 {
     internal interface ITcpServer
     {
-        delegate void OnConnectionHandler(IXFireClient sessionContext);
+        delegate Task OnConnectionHandler(IXFireClient sessionContext);
 
-        delegate void OnDisconnectionHandler(IXFireClient sessionContext);
+        delegate Task OnDisconnectionHandler(IXFireClient sessionContext);
 
-        delegate void OnReceiveHandler(IXFireClient sessionContext, IMessage message);
+        delegate Task OnReceiveHandler(IXFireClient sessionContext, IMessage message);
 
         event OnReceiveHandler OnReceive;
         event OnConnectionHandler OnConnection;

--- a/src/PFire.Core/PFireServer.cs
+++ b/src/PFire.Core/PFireServer.cs
@@ -54,7 +54,7 @@ namespace PFire.Core
 
         private async Task UpdateFriendsWithDisconnetedStatus(IXFireClient disconnectedClient)
         {
-            var friends = await Database.QueryFriends(disconnectedClient.User);
+            var friends = Database.QueryFriends(disconnectedClient.User);
 
             foreach (var friend in friends)
             {

--- a/src/PFire.Core/PFireServer.cs
+++ b/src/PFire.Core/PFireServer.cs
@@ -54,7 +54,7 @@ namespace PFire.Core
 
         private async Task UpdateFriendsWithDisconnetedStatus(IXFireClient disconnectedClient)
         {
-            var friends = Database.QueryFriends(disconnectedClient.User);
+            var friends = await Database.QueryFriends(disconnectedClient.User);
 
             foreach (var friend in friends)
             {

--- a/src/PFire.Core/Protocol/Messages/Bidirectional/ChatContent.cs
+++ b/src/PFire.Core/Protocol/Messages/Bidirectional/ChatContent.cs
@@ -5,9 +5,9 @@
         public ChatContent() : base(XFireMessageType.ServerChatMessage) {}
 
         [XMessageField("imindex")]
-        public int MessageOrderIndex { get; }
+        public int MessageOrderIndex { get; set; }
 
         [XMessageField("im")]
-        public string MessageContent { get; }
+        public string MessageContent { get; set; }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Bidirectional/ChatMessage.cs
+++ b/src/PFire.Core/Protocol/Messages/Bidirectional/ChatMessage.cs
@@ -14,10 +14,10 @@ namespace PFire.Core.Protocol.Messages.Bidirectional
         public ChatMessage() : base(XFireMessageType.ServerChatMessage) {}
 
         [XMessageField("sid")]
-        public Guid SessionId { get; private set; }
+        public Guid SessionId { get; set; }
 
         [XMessageField("peermsg")]
-        public Dictionary<string, dynamic> MessagePayload { get; private set; }
+        public Dictionary<string, dynamic> MessagePayload { get; set; }
 
         // TODO: Create test for this message so we can refactor and build this message the same way as the others to avoid the switch statement
         // TODO: How to tell the client we didn't receive the ACK?

--- a/src/PFire.Core/Protocol/Messages/Bidirectional/ChatMessage.cs
+++ b/src/PFire.Core/Protocol/Messages/Bidirectional/ChatMessage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PFire.Core.Protocol.Messages.MessageEnums;
 using PFire.Core.Session;
@@ -21,13 +22,12 @@ namespace PFire.Core.Protocol.Messages.Bidirectional
         // TODO: Create test for this message so we can refactor and build this message the same way as the others to avoid the switch statement
         // TODO: How to tell the client we didn't receive the ACK?
         // TODO: P2P stuff???
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             var otherSession = context.Server.GetSession(SessionId);
-
             if (otherSession == null)
             {
-                return;
+                return Task.CompletedTask;
             }
 
             var messageType = (ChatMessageType)(byte)MessagePayload["msgtype"];
@@ -51,6 +51,8 @@ namespace PFire.Core.Protocol.Messages.Bidirectional
                     context.Logger.LogDebug($"NOT BUILT: Got {messageType} for session: {context.SessionId}");
                     break;
             }
+
+            return Task.CompletedTask;
         }
 
         private ChatMessage BuildChatMessageResponse(Guid sessionId)

--- a/src/PFire.Core/Protocol/Messages/Bidirectional/ChatMessage.cs
+++ b/src/PFire.Core/Protocol/Messages/Bidirectional/ChatMessage.cs
@@ -22,12 +22,12 @@ namespace PFire.Core.Protocol.Messages.Bidirectional
         // TODO: Create test for this message so we can refactor and build this message the same way as the others to avoid the switch statement
         // TODO: How to tell the client we didn't receive the ACK?
         // TODO: P2P stuff???
-        public override Task Process(IXFireClient context)
+        public override async Task Process(IXFireClient context)
         {
             var otherSession = context.Server.GetSession(SessionId);
             if (otherSession == null)
             {
-                return Task.CompletedTask;
+                return;
             }
 
             var messageType = (ChatMessageType)(byte)MessagePayload["msgtype"];
@@ -36,23 +36,21 @@ namespace PFire.Core.Protocol.Messages.Bidirectional
             {
                 case ChatMessageType.Content:
                     var responseAck = BuildAckResponse(otherSession.SessionId);
-                    context.SendMessage(responseAck);
+                    await context.SendMessage(responseAck);
 
                     var chatMsg = BuildChatMessageResponse(context.SessionId);
-                    otherSession.SendMessage(chatMsg);
+                    await otherSession.SendMessage(chatMsg);
                     break;
 
                 case ChatMessageType.TypingNotification:
                     var typingMsg = BuildChatMessageResponse(context.SessionId);
-                    otherSession.SendMessage(typingMsg);
+                    await otherSession.SendMessage(typingMsg);
                     break;
 
                 default:
                     context.Logger.LogDebug($"NOT BUILT: Got {messageType} for session: {context.SessionId}");
                     break;
             }
-
-            return Task.CompletedTask;
         }
 
         private ChatMessage BuildChatMessageResponse(Guid sessionId)

--- a/src/PFire.Core/Protocol/Messages/Bidirectional/ChatTypingNotification.cs
+++ b/src/PFire.Core/Protocol/Messages/Bidirectional/ChatTypingNotification.cs
@@ -8,9 +8,9 @@
         public ChatTypingNotification() : base(XFireMessageType.ServerChatMessage) {}
 
         [XMessageField("imindex")]
-        public int OrderIndex { get; private set; }
+        public int OrderIndex { get; set; }
 
         [XMessageField("typing")]
-        public int Typing { get; private set; }
+        public int Typing { get; set; }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/IMessage.cs
+++ b/src/PFire.Core/Protocol/Messages/IMessage.cs
@@ -1,10 +1,11 @@
-﻿using PFire.Core.Session;
+﻿using System.Threading.Tasks;
+using PFire.Core.Session;
 
 namespace PFire.Core.Protocol.Messages
 {
     internal interface IMessage
     {
         XFireMessageType MessageTypeId { get; }
-        void Process(IXFireClient client);
+        Task Process(IXFireClient client);
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/ClientConfiguration.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/ClientConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using PFire.Core.Protocol.Messages.Outbound;
+﻿using System.Threading.Tasks;
+using PFire.Core.Protocol.Messages.Outbound;
 using PFire.Core.Session;
 
 namespace PFire.Core.Protocol.Messages.Inbound
@@ -19,9 +20,11 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField("partner")]
         public string Partner { get; set; }
 
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             context.SendAndProcessMessage(new Did());
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/ClientConfiguration.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/ClientConfiguration.cs
@@ -20,11 +20,10 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField("partner")]
         public string Partner { get; set; }
 
-        public override Task Process(IXFireClient context)
+        public override async Task Process(IXFireClient context)
         {
-            context.SendAndProcessMessage(new Did());
+            await context.SendAndProcessMessage(new Did());
 
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/ClientVersion.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/ClientVersion.cs
@@ -14,13 +14,11 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField("major_version")]
         public int MajorVersion { get; private set; }
 
-        public override Task Process(IXFireClient context)
+        public override async Task Process(IXFireClient context)
         {
             var loginChallenge = new LoginChallenge();
-            loginChallenge.Process(context);
-            context.SendMessage(loginChallenge);
-
-            return Task.CompletedTask;
+            await loginChallenge.Process(context);
+            await context.SendMessage(loginChallenge);
         }
 
         public override string ToString()

--- a/src/PFire.Core/Protocol/Messages/Inbound/ClientVersion.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/ClientVersion.cs
@@ -1,4 +1,5 @@
-﻿using PFire.Core.Protocol.Messages.Outbound;
+﻿using System.Threading.Tasks;
+using PFire.Core.Protocol.Messages.Outbound;
 using PFire.Core.Session;
 
 namespace PFire.Core.Protocol.Messages.Inbound
@@ -13,11 +14,13 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField("major_version")]
         public int MajorVersion { get; private set; }
 
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             var loginChallenge = new LoginChallenge();
             loginChallenge.Process(context);
             context.SendMessage(loginChallenge);
+
+            return Task.CompletedTask;
         }
 
         public override string ToString()

--- a/src/PFire.Core/Protocol/Messages/Inbound/ClientVersion.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/ClientVersion.cs
@@ -9,10 +9,10 @@ namespace PFire.Core.Protocol.Messages.Inbound
         public ClientVersion() : base(XFireMessageType.ClientVersion) {}
 
         [XMessageField("version")]
-        public int Version { get; private set; }
+        public int Version { get; set; }
 
         [XMessageField("major_version")]
-        public int MajorVersion { get; private set; }
+        public int MajorVersion { get; set; }
 
         public override async Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Inbound/ConnectionInformation.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/ConnectionInformation.cs
@@ -51,7 +51,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
 
             // Tell friends this user came online
             //if (context.User.Username == "test") Debugger.Break();
-            var friends = context.Server.Database.QueryFriends(context.User);
+            var friends = await context.Server.Database.QueryFriends(context.User);
             foreach (var friend in friends)
             {
                 var otherSession = context.Server.GetSession(friend);
@@ -61,10 +61,10 @@ namespace PFire.Core.Protocol.Messages.Inbound
                 }
             }
 
-            var pendingFriendRequests = context.Server.Database.QueryPendingFriendRequests(context.User);
+            var pendingFriendRequests = await context.Server.Database.QueryPendingFriendRequests(context.User);
             foreach (var request in pendingFriendRequests)
             {
-                var requester = context.Server.Database.QueryUser(request.UserId);
+                var requester = await context.Server.Database.QueryUser(request.UserId);
                 await context.SendAndProcessMessage(new FriendInvite(requester.Username, requester.Nickname, request.Message));
             }
         }

--- a/src/PFire.Core/Protocol/Messages/Inbound/ConnectionInformation.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/ConnectionInformation.cs
@@ -51,7 +51,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
 
             // Tell friends this user came online
             //if (context.User.Username == "test") Debugger.Break();
-            var friends = await context.Server.Database.QueryFriends(context.User);
+            var friends = context.Server.Database.QueryFriends(context.User);
             foreach (var friend in friends)
             {
                 var otherSession = context.Server.GetSession(friend);
@@ -61,10 +61,10 @@ namespace PFire.Core.Protocol.Messages.Inbound
                 }
             }
 
-            var pendingFriendRequests = await context.Server.Database.QueryPendingFriendRequests(context.User);
+            var pendingFriendRequests = context.Server.Database.QueryPendingFriendRequests(context.User);
             foreach (var request in pendingFriendRequests)
             {
-                var requester = await context.Server.Database.QueryUser(request.Id);
+                var requester = context.Server.Database.QueryUser(request.UserId);
                 await context.SendAndProcessMessage(new FriendInvite(requester.Username, requester.Nickname, request.Message));
             }
         }

--- a/src/PFire.Core/Protocol/Messages/Inbound/ConnectionInformation.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/ConnectionInformation.cs
@@ -1,4 +1,5 @@
-﻿using PFire.Core.Protocol.Messages.Outbound;
+﻿using System.Threading.Tasks;
+using PFire.Core.Protocol.Messages.Outbound;
 using PFire.Core.Session;
 
 namespace PFire.Core.Protocol.Messages.Inbound
@@ -25,7 +26,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField("upnpinfo")]
         public string UpnpInfo { get; private set; }
 
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             var clientPrefs = new Unknown10();
             context.SendAndProcessMessage(clientPrefs);
@@ -63,6 +64,8 @@ namespace PFire.Core.Protocol.Messages.Inbound
                 var requester = context.Server.Database.QueryUser(request.UserId);
                 context.SendAndProcessMessage(new FriendInvite(requester.Username, requester.Nickname, request.Message));
             });
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/ConnectionInformation.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/ConnectionInformation.cs
@@ -26,46 +26,47 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField("upnpinfo")]
         public string UpnpInfo { get; private set; }
 
-        public override Task Process(IXFireClient context)
+        public override async Task Process(IXFireClient context)
         {
             var clientPrefs = new Unknown10();
-            context.SendAndProcessMessage(clientPrefs);
+            await context.SendAndProcessMessage(clientPrefs);
 
             var groups = new Groups();
-            context.SendAndProcessMessage(groups);
+            await context.SendAndProcessMessage(groups);
 
             var groupsFriends = new GroupsFriends();
-            context.SendAndProcessMessage(groupsFriends);
+            await context.SendAndProcessMessage(groupsFriends);
 
             var serverList = new ServerList();
-            context.SendAndProcessMessage(serverList);
+            await context.SendAndProcessMessage(serverList);
 
             var chatRooms = new ChatRooms();
-            context.SendAndProcessMessage(chatRooms);
+            await context.SendAndProcessMessage(chatRooms);
 
             var friendsList = new FriendsList(context.User);
-            context.SendAndProcessMessage(friendsList);
+            await context.SendAndProcessMessage(friendsList);
 
             var friendsStatus = new FriendsSessionAssign(context.User);
-            context.SendAndProcessMessage(friendsStatus);
+            await context.SendAndProcessMessage(friendsStatus);
 
             // Tell friends this user came online
             //if (context.User.Username == "test") Debugger.Break();
-            var friends = context.Server.Database.QueryFriends(context.User);
-            friends.ForEach(friend =>
+            var friends = await context.Server.Database.QueryFriends(context.User);
+            foreach (var friend in friends)
             {
                 var otherSession = context.Server.GetSession(friend);
-                otherSession?.SendAndProcessMessage(new FriendsSessionAssign(friend));
-            });
+                if (otherSession != null)
+                {
+                    await otherSession.SendAndProcessMessage(new FriendsSessionAssign(friend));
+                }
+            }
 
-            var pendingFriendRequests = context.Server.Database.QueryPendingFriendRequests(context.User);
-            pendingFriendRequests.ForEach(request =>
+            var pendingFriendRequests = await context.Server.Database.QueryPendingFriendRequests(context.User);
+            foreach (var request in pendingFriendRequests)
             {
-                var requester = context.Server.Database.QueryUser(request.UserId);
-                context.SendAndProcessMessage(new FriendInvite(requester.Username, requester.Nickname, request.Message));
-            });
-
-            return Task.CompletedTask;
+                var requester = await context.Server.Database.QueryUser(request.Id);
+                await context.SendAndProcessMessage(new FriendInvite(requester.Username, requester.Nickname, request.Message));
+            }
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/ConnectionInformation.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/ConnectionInformation.cs
@@ -9,22 +9,22 @@ namespace PFire.Core.Protocol.Messages.Inbound
         public ConnectionInformation() : base(XFireMessageType.ConnectionInformation) {}
 
         [XMessageField("conn")]
-        public int Connection { get; private set; }
+        public int Connection { get; set; }
 
         [XMessageField("nat")]
-        public int Nat { get; private set; }
+        public int Nat { get; set; }
 
         [XMessageField("naterr")]
-        public int NatError { get; private set; }
+        public int NatError { get; set; }
 
         [XMessageField("sec")]
-        public int Sec { get; private set; }
+        public int Sec { get; set; }
 
         [XMessageField("clientip")]
-        public int ClientIp { get; private set; }
+        public int ClientIp { get; set; }
 
         [XMessageField("upnpinfo")]
-        public string UpnpInfo { get; private set; }
+        public string UpnpInfo { get; set; }
 
         public override async Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Inbound/FriendRequest.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/FriendRequest.cs
@@ -14,18 +14,19 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField("msg")]
         public string Message { get; private set; }
 
-        public override Task Process(IXFireClient context)
+        public override async Task Process(IXFireClient context)
         {
-            var recipient = context.Server.Database.QueryUser(Username);
+            var recipient = await context.Server.Database.QueryUser(Username);
             var invite = new FriendInvite(context.User.Username, context.User.Nickname, Message);
-            invite.Process(context);
+            await invite.Process(context);
 
-            context.Server.Database.InsertFriendRequest(context.User, Username, Message);
+            await context.Server.Database.InsertFriendRequest(context.User, Username, Message);
 
             var recipientSession = context.Server.GetSession(recipient);
-            recipientSession?.SendMessage(invite);
-
-            return Task.CompletedTask;
+            if (recipientSession != null)
+            {
+                await recipientSession.SendMessage(invite);
+            }
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/FriendRequest.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/FriendRequest.cs
@@ -16,11 +16,11 @@ namespace PFire.Core.Protocol.Messages.Inbound
 
         public override async Task Process(IXFireClient context)
         {
-            var recipient = await context.Server.Database.QueryUser(Username);
+            var recipient = context.Server.Database.QueryUser(Username);
             var invite = new FriendInvite(context.User.Username, context.User.Nickname, Message);
             await invite.Process(context);
 
-            await context.Server.Database.InsertFriendRequest(context.User, Username, Message);
+            context.Server.Database.InsertFriendRequest(context.User, Username, Message);
 
             var recipientSession = context.Server.GetSession(recipient);
             if (recipientSession != null)

--- a/src/PFire.Core/Protocol/Messages/Inbound/FriendRequest.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/FriendRequest.cs
@@ -9,10 +9,10 @@ namespace PFire.Core.Protocol.Messages.Inbound
         public FriendRequest() : base(XFireMessageType.FriendRequest) {}
 
         [XMessageField("name")]
-        public string Username { get; private set; }
+        public string Username { get; set; }
 
         [XMessageField("msg")]
-        public string Message { get; private set; }
+        public string Message { get; set; }
 
         public override async Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Inbound/FriendRequest.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/FriendRequest.cs
@@ -16,11 +16,11 @@ namespace PFire.Core.Protocol.Messages.Inbound
 
         public override async Task Process(IXFireClient context)
         {
-            var recipient = context.Server.Database.QueryUser(Username);
+            var recipient = await context.Server.Database.QueryUser(Username);
             var invite = new FriendInvite(context.User.Username, context.User.Nickname, Message);
             await invite.Process(context);
 
-            context.Server.Database.InsertFriendRequest(context.User, Username, Message);
+            await context.Server.Database.InsertFriendRequest(context.User, Username, Message);
 
             var recipientSession = context.Server.GetSession(recipient);
             if (recipientSession != null)

--- a/src/PFire.Core/Protocol/Messages/Inbound/FriendRequest.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/FriendRequest.cs
@@ -1,4 +1,5 @@
-﻿using PFire.Core.Protocol.Messages.Outbound;
+﻿using System.Threading.Tasks;
+using PFire.Core.Protocol.Messages.Outbound;
 using PFire.Core.Session;
 
 namespace PFire.Core.Protocol.Messages.Inbound
@@ -13,7 +14,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField("msg")]
         public string Message { get; private set; }
 
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             var recipient = context.Server.Database.QueryUser(Username);
             var invite = new FriendInvite(context.User.Username, context.User.Nickname, Message);
@@ -23,6 +24,8 @@ namespace PFire.Core.Protocol.Messages.Inbound
 
             var recipientSession = context.Server.GetSession(recipient);
             recipientSession?.SendMessage(invite);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestAccept.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestAccept.cs
@@ -14,9 +14,9 @@ namespace PFire.Core.Protocol.Messages.Inbound
 
         public override async Task Process(IXFireClient context)
         {
-            var friend = await context.Server.Database.QueryUser(FriendUsername);
+            var friend = context.Server.Database.QueryUser(FriendUsername);
 
-            await context.Server.Database.InsertMutualFriend(context.User, friend);
+            context.Server.Database.InsertMutualFriend(context.User, friend);
 
             await context.SendAndProcessMessage(new FriendsList(context.User));
             await context.SendAndProcessMessage(new FriendsSessionAssign(context.User));
@@ -29,11 +29,11 @@ namespace PFire.Core.Protocol.Messages.Inbound
                 await friendSession.SendAndProcessMessage(new FriendsSessionAssign(friend));
             }
 
-            var pendingRequests = await context.Server.Database.QueryPendingFriendRequests(context.User);
-            var pq = pendingRequests.FirstOrDefault(a => a.FriendUserId == context.User.Id);
+            var pendingRequests = context.Server.Database.QueryPendingFriendRequests(context.User);
+            var pq = pendingRequests.FirstOrDefault(a => a.FriendUserId == context.User.UserId);
             if (pq != null)
             {
-                await context.Server.Database.DeletePendingFriendRequest(pq.Id);
+                context.Server.Database.DeletePendingFriendRequest(pq.PendingFriendRequestId);
             }
         }
     }

--- a/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestAccept.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestAccept.cs
@@ -14,9 +14,9 @@ namespace PFire.Core.Protocol.Messages.Inbound
 
         public override async Task Process(IXFireClient context)
         {
-            var friend = context.Server.Database.QueryUser(FriendUsername);
+            var friend = await context.Server.Database.QueryUser(FriendUsername);
 
-            context.Server.Database.InsertMutualFriend(context.User, friend);
+            await context.Server.Database.InsertMutualFriend(context.User, friend);
 
             await context.SendAndProcessMessage(new FriendsList(context.User));
             await context.SendAndProcessMessage(new FriendsSessionAssign(context.User));
@@ -29,11 +29,11 @@ namespace PFire.Core.Protocol.Messages.Inbound
                 await friendSession.SendAndProcessMessage(new FriendsSessionAssign(friend));
             }
 
-            var pendingRequests = context.Server.Database.QueryPendingFriendRequests(context.User);
+            var pendingRequests = await context.Server.Database.QueryPendingFriendRequests(context.User);
             var pq = pendingRequests.FirstOrDefault(a => a.FriendUserId == context.User.UserId);
             if (pq != null)
             {
-                context.Server.Database.DeletePendingFriendRequest(pq.PendingFriendRequestId);
+                await context.Server.Database.DeletePendingFriendRequest(pq.PendingFriendRequestId);
             }
         }
     }

--- a/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestAccept.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestAccept.cs
@@ -10,7 +10,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
         public FriendRequestAccept() : base(XFireMessageType.FriendRequestAccept) {}
 
         [XMessageField("name")]
-        public string FriendUsername { get; private set; }
+        public string FriendUsername { get; set; }
 
         public override async Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestAccept.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestAccept.cs
@@ -1,3 +1,4 @@
+﻿using System.Threading.Tasks;
 ﻿using System.Linq;
 using PFire.Core.Protocol.Messages.Outbound;
 using PFire.Core.Session;
@@ -11,7 +12,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField("name")]
         public string FriendUsername { get; private set; }
 
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             var friend = context.Server.Database.QueryUser(FriendUsername);
 
@@ -34,6 +35,8 @@ namespace PFire.Core.Protocol.Messages.Inbound
             {
                 context.Server.Database.DeletePendingFriendRequest(pq.PendingFriendRequestId);
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestDecline.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestDecline.cs
@@ -13,14 +13,14 @@ namespace PFire.Core.Protocol.Messages.Inbound
 
         public override async Task Process(IXFireClient context)
         {
-            var requesterUser = context.Server.Database.QueryUser(RequesterUsername);
-            var pendingRequests = context.Server.Database.QueryPendingFriendRequestsSelf(requesterUser);
+            var requesterUser = await context.Server.Database.QueryUser(RequesterUsername);
+            var pendingRequests = await context.Server.Database.QueryPendingFriendRequestsSelf(requesterUser);
 
             var requestsIds = pendingRequests.Where(a => a.UserId == requesterUser.UserId && a.FriendUserId == context.User.UserId)
                                              .Select(a => a.PendingFriendRequestId)
                                              .ToArray();
 
-            context.Server.Database.DeletePendingFriendRequest(requestsIds);
+            await context.Server.Database.DeletePendingFriendRequest(requestsIds);
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestDecline.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestDecline.cs
@@ -9,7 +9,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
         public FriendRequestDecline() : base(XFireMessageType.FriendRequestDecline) {}
 
         [XMessageField("name")]
-        public string RequesterUsername { get; private set; }
+        public string RequesterUsername { get; set; }
 
         public override async Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestDecline.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestDecline.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using PFire.Core.Session;
 
 namespace PFire.Core.Protocol.Messages.Inbound
@@ -10,7 +11,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField("name")]
         public string RequesterUsername { get; private set; }
 
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             var requesterUser = context.Server.Database.QueryUser(RequesterUsername);
             var pendingRequests = context.Server.Database.QueryPendingFriendRequestsSelf(requesterUser);
@@ -20,6 +21,8 @@ namespace PFire.Core.Protocol.Messages.Inbound
                                              .ToArray();
 
             context.Server.Database.DeletePendingFriendRequest(requestsIds);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestDecline.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestDecline.cs
@@ -11,18 +11,14 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField("name")]
         public string RequesterUsername { get; private set; }
 
-        public override Task Process(IXFireClient context)
+        public override async Task Process(IXFireClient context)
         {
-            var requesterUser = context.Server.Database.QueryUser(RequesterUsername);
-            var pendingRequests = context.Server.Database.QueryPendingFriendRequestsSelf(requesterUser);
+            var requesterUser = await context.Server.Database.QueryUser(RequesterUsername);
+            var pendingRequests = await context.Server.Database.QueryPendingFriendRequestsSelf(requesterUser);
 
-            var requestsIds = pendingRequests.Where(a => a.UserId == requesterUser.UserId && a.FriendUserId == context.User.UserId)
-                                             .Select(a => a.PendingFriendRequestId)
-                                             .ToArray();
+            var requestsIds = pendingRequests.Where(a => a.Id == requesterUser.Id && a.FriendUserId == context.User.Id).Select(a => a.Id).ToArray();
 
-            context.Server.Database.DeletePendingFriendRequest(requestsIds);
-
-            return Task.CompletedTask;
+            await context.Server.Database.DeletePendingFriendRequest(requestsIds);
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestDecline.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/FriendRequestDecline.cs
@@ -13,12 +13,14 @@ namespace PFire.Core.Protocol.Messages.Inbound
 
         public override async Task Process(IXFireClient context)
         {
-            var requesterUser = await context.Server.Database.QueryUser(RequesterUsername);
-            var pendingRequests = await context.Server.Database.QueryPendingFriendRequestsSelf(requesterUser);
+            var requesterUser = context.Server.Database.QueryUser(RequesterUsername);
+            var pendingRequests = context.Server.Database.QueryPendingFriendRequestsSelf(requesterUser);
 
-            var requestsIds = pendingRequests.Where(a => a.Id == requesterUser.Id && a.FriendUserId == context.User.Id).Select(a => a.Id).ToArray();
+            var requestsIds = pendingRequests.Where(a => a.UserId == requesterUser.UserId && a.FriendUserId == context.User.UserId)
+                                             .Select(a => a.PendingFriendRequestId)
+                                             .ToArray();
 
-            await context.Server.Database.DeletePendingFriendRequest(requestsIds);
+            context.Server.Database.DeletePendingFriendRequest(requestsIds);
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/GameInformation.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/GameInformation.cs
@@ -5,12 +5,12 @@
         public GameInformation() : base(XFireMessageType.GameInformation) {}
 
         [XMessageField("gameid")]
-        public int GameId { get; private set; }
+        public int GameId { get; set; }
 
         [XMessageField("gip")]
-        public int GameIP { get; private set; }
+        public int GameIP { get; set; }
 
         [XMessageField("gport")]
-        public int GamePort { get; private set; }
+        public int GamePort { get; set; }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/LoginRequest.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/LoginRequest.cs
@@ -19,7 +19,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
 
         public override async Task Process(IXFireClient context)
         {
-            var user = await context.Server.Database.QueryUser(Username);
+            var user = context.Server.Database.QueryUser(Username);
             if (user != null)
             {
                 if (user.Password != Password)
@@ -31,7 +31,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
             }
             else
             {
-                user = await context.Server.Database.InsertUser(Username, Password, context.Salt);
+                user = context.Server.Database.InsertUser(Username, Password, context.Salt);
             }
 
             // Remove any older sessions from this user (duplicate logins)

--- a/src/PFire.Core/Protocol/Messages/Inbound/LoginRequest.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/LoginRequest.cs
@@ -17,20 +17,21 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField("flags")]
         public int Flags { get; private set; }
 
-        public override Task Process(IXFireClient context)
+        public override async Task Process(IXFireClient context)
         {
-            var user = context.Server.Database.QueryUser(Username);
+            var user = await context.Server.Database.QueryUser(Username);
             if (user != null)
             {
                 if (user.Password != Password)
                 {
-                    context.SendAndProcessMessage(new LoginFailure());
+                    await context.SendAndProcessMessage(new LoginFailure());
+
                     return;
                 }
-                }
+            }
             else
             {
-                user = context.Server.Database.InsertUser(Username, Password, context.Salt);
+                user = await context.Server.Database.InsertUser(Username, Password, context.Salt);
             }
 
             // Remove any older sessions from this user (duplicate logins)
@@ -39,9 +40,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
             context.User = user;
 
             var success = new LoginSuccess();
-            context.SendAndProcessMessage(success);
-
-            return Task.CompletedTask;
+            await context.SendAndProcessMessage(success);
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/LoginRequest.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/LoginRequest.cs
@@ -9,13 +9,13 @@ namespace PFire.Core.Protocol.Messages.Inbound
         public LoginRequest() : base(XFireMessageType.LoginRequest) {}
 
         [XMessageField("name")]
-        public string Username { get; private set; }
+        public string Username { get; set; }
 
         [XMessageField("password")]
-        public string Password { get; private set; }
+        public string Password { get; set; }
 
         [XMessageField("flags")]
-        public int Flags { get; private set; }
+        public int Flags { get; set; }
 
         public override async Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Inbound/LoginRequest.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/LoginRequest.cs
@@ -1,4 +1,5 @@
-﻿using PFire.Core.Protocol.Messages.Outbound;
+﻿using System.Threading.Tasks;
+using PFire.Core.Protocol.Messages.Outbound;
 using PFire.Core.Session;
 
 namespace PFire.Core.Protocol.Messages.Inbound
@@ -16,7 +17,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField("flags")]
         public int Flags { get; private set; }
 
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             var user = context.Server.Database.QueryUser(Username);
             if (user != null)
@@ -26,7 +27,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
                     context.SendAndProcessMessage(new LoginFailure());
                     return;
                 }
-            }
+                }
             else
             {
                 user = context.Server.Database.InsertUser(Username, Password, context.Salt);
@@ -39,6 +40,8 @@ namespace PFire.Core.Protocol.Messages.Inbound
 
             var success = new LoginSuccess();
             context.SendAndProcessMessage(success);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/LoginRequest.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/LoginRequest.cs
@@ -19,7 +19,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
 
         public override async Task Process(IXFireClient context)
         {
-            var user = context.Server.Database.QueryUser(Username);
+            var user = await context.Server.Database.QueryUser(Username);
             if (user != null)
             {
                 if (user.Password != Password)
@@ -31,7 +31,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
             }
             else
             {
-                user = context.Server.Database.InsertUser(Username, Password, context.Salt);
+                user = await context.Server.Database.InsertUser(Username, Password, context.Salt);
             }
 
             // Remove any older sessions from this user (duplicate logins)

--- a/src/PFire.Core/Protocol/Messages/Inbound/NicknameChange.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/NicknameChange.cs
@@ -11,7 +11,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
         public NicknameChange() : base(XFireMessageType.NicknameChange) {}
 
         [XMessageField("nick")]
-        public string Nickname { get; private set; }
+        public string Nickname { get; set; }
 
         public override async Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Inbound/NicknameChange.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/NicknameChange.cs
@@ -20,10 +20,10 @@ namespace PFire.Core.Protocol.Messages.Inbound
                 Nickname = Nickname.Substring(0, MAX_LENGTH);
             }
 
-            await context.Server.Database.UpdateNickname(context.User, Nickname);
+            context.Server.Database.UpdateNickname(context.User, Nickname);
 
             var updatedFriendsList = new FriendsList(context.User);
-            var queryFriends = await context.Server.Database.QueryFriends(context.User);
+            var queryFriends = context.Server.Database.QueryFriends(context.User);
             foreach (var friend in queryFriends)
             {
                 var friendSession = context.Server.GetSession(friend);

--- a/src/PFire.Core/Protocol/Messages/Inbound/NicknameChange.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/NicknameChange.cs
@@ -1,4 +1,5 @@
-﻿using PFire.Core.Protocol.Messages.Outbound;
+﻿using System.Threading.Tasks;
+using PFire.Core.Protocol.Messages.Outbound;
 using PFire.Core.Session;
 
 namespace PFire.Core.Protocol.Messages.Inbound
@@ -12,7 +13,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField("nick")]
         public string Nickname { get; private set; }
 
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             if (Nickname.Length > MAX_LENGTH)
             {
@@ -24,10 +25,12 @@ namespace PFire.Core.Protocol.Messages.Inbound
             var updatedFriendsList = new FriendsList(context.User);
             context.Server.Database.QueryFriends(context.User)
                    .ForEach(friend =>
-                   {
-                       var friendSession = context.Server.GetSession(friend);
-                       friendSession?.SendAndProcessMessage(updatedFriendsList);
-                   });
+            {
+                var friendSession = context.Server.GetSession(friend);
+                friendSession?.SendAndProcessMessage(updatedFriendsList);
+            });
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/NicknameChange.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/NicknameChange.cs
@@ -20,10 +20,10 @@ namespace PFire.Core.Protocol.Messages.Inbound
                 Nickname = Nickname.Substring(0, MAX_LENGTH);
             }
 
-            context.Server.Database.UpdateNickname(context.User, Nickname);
+            await context.Server.Database.UpdateNickname(context.User, Nickname);
 
             var updatedFriendsList = new FriendsList(context.User);
-            var queryFriends = context.Server.Database.QueryFriends(context.User);
+            var queryFriends = await context.Server.Database.QueryFriends(context.User);
             foreach (var friend in queryFriends)
             {
                 var friendSession = context.Server.GetSession(friend);

--- a/src/PFire.Core/Protocol/Messages/Inbound/StatusChange.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/StatusChange.cs
@@ -14,7 +14,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
         public override async Task Process(IXFireClient context)
         {
             var statusChange = new FriendStatusChange(context.SessionId, Message);
-            var friends = await context.Server.Database.QueryFriends(context.User);
+            var friends = context.Server.Database.QueryFriends(context.User);
             foreach (var friend in friends)
             {
                 var friendSession = context.Server.GetSession(friend);

--- a/src/PFire.Core/Protocol/Messages/Inbound/StatusChange.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/StatusChange.cs
@@ -14,7 +14,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
         public override async Task Process(IXFireClient context)
         {
             var statusChange = new FriendStatusChange(context.SessionId, Message);
-            var friends = context.Server.Database.QueryFriends(context.User);
+            var friends = await context.Server.Database.QueryFriends(context.User);
             foreach (var friend in friends)
             {
                 var friendSession = context.Server.GetSession(friend);

--- a/src/PFire.Core/Protocol/Messages/Inbound/StatusChange.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/StatusChange.cs
@@ -1,4 +1,5 @@
-﻿using PFire.Core.Protocol.Messages.Outbound;
+﻿using System.Threading.Tasks;
+using PFire.Core.Protocol.Messages.Outbound;
 using PFire.Core.Session;
 
 namespace PFire.Core.Protocol.Messages.Inbound
@@ -10,7 +11,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField(0x2e)]
         public string Message { get; private set; }
 
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             var statusChange = new FriendStatusChange(context.SessionId, Message);
             var friends = context.Server.Database.QueryFriends(context.User);
@@ -19,6 +20,8 @@ namespace PFire.Core.Protocol.Messages.Inbound
                 var friendSession = context.Server.GetSession(friend);
                 friendSession?.SendAndProcessMessage(statusChange);
             });
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/StatusChange.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/StatusChange.cs
@@ -9,7 +9,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
         public StatusChange() : base(XFireMessageType.StatusChange) {}
 
         [XMessageField(0x2e)]
-        public string Message { get; private set; }
+        public string Message { get; set; }
 
         public override async Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Inbound/StatusChange.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/StatusChange.cs
@@ -11,17 +11,18 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField(0x2e)]
         public string Message { get; private set; }
 
-        public override Task Process(IXFireClient context)
+        public override async Task Process(IXFireClient context)
         {
             var statusChange = new FriendStatusChange(context.SessionId, Message);
-            var friends = context.Server.Database.QueryFriends(context.User);
-            friends.ForEach(friend =>
+            var friends = await context.Server.Database.QueryFriends(context.User);
+            foreach (var friend in friends)
             {
                 var friendSession = context.Server.GetSession(friend);
-                friendSession?.SendAndProcessMessage(statusChange);
-            });
-
-            return Task.CompletedTask;
+                if (friendSession != null)
+                {
+                    await friendSession.SendAndProcessMessage(statusChange);
+                }
+            }
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/UserLookup.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/UserLookup.cs
@@ -9,16 +9,16 @@ namespace PFire.Core.Protocol.Messages.Inbound
         public UserLookup() : base(XFireMessageType.UserLookup) {}
 
         [XMessageField("name")]
-        public string Username { get; private set; }
+        public string Username { get; set; }
 
         [XMessageField("fname")]
-        public string FirstName { get; private set; }
+        public string FirstName { get; set; }
 
         [XMessageField("lname")]
-        public string LastName { get; private set; }
+        public string LastName { get; set; }
 
         [XMessageField("email")]
-        public string Email { get; private set; }
+        public string Email { get; set; }
 
         public override async Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Inbound/UserLookup.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/UserLookup.cs
@@ -1,4 +1,5 @@
-﻿using PFire.Core.Protocol.Messages.Outbound;
+﻿using System.Threading.Tasks;
+using PFire.Core.Protocol.Messages.Outbound;
 using PFire.Core.Session;
 
 namespace PFire.Core.Protocol.Messages.Inbound
@@ -19,10 +20,12 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField("email")]
         public string Email { get; private set; }
 
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             var result = new UserLookupResult(Username);
             context.SendAndProcessMessage(result);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/UserLookup.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/UserLookup.cs
@@ -20,12 +20,10 @@ namespace PFire.Core.Protocol.Messages.Inbound
         [XMessageField("email")]
         public string Email { get; private set; }
 
-        public override Task Process(IXFireClient context)
+        public override async Task Process(IXFireClient context)
         {
             var result = new UserLookupResult(Username);
-            context.SendAndProcessMessage(result);
-
-            return Task.CompletedTask;
+            await context.SendAndProcessMessage(result);
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/ClientPreferences.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/ClientPreferences.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using PFire.Core.Session;
 
 namespace PFire.Core.Protocol.Messages.Outbound
@@ -10,7 +11,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
         [XMessageField(0x4c)]
         public Dictionary<byte, string> preferences { get; private set; }
 
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             preferences = new Dictionary<byte, string>
             {
@@ -51,6 +52,8 @@ namespace PFire.Core.Protocol.Messages.Outbound
                     21, "0"
                 }
             };
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/ClientPreferences.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/ClientPreferences.cs
@@ -9,7 +9,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
         public ClientPreferences() : base(XFireMessageType.ClientPreferences) {}
 
         [XMessageField(0x4c)]
-        public Dictionary<byte, string> preferences { get; private set; }
+        public Dictionary<byte, string> preferences { get; set; }
 
         public override Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsList.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsList.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using PFire.Core.Session;
 using PFire.Infrastructure.Database;
 
@@ -26,7 +27,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
         [XMessageField("nick")]
         public List<string> Nicks { get; }
 
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             var friends = context.Server.Database.QueryFriends(_ownerUser);
             friends.ForEach(f =>
@@ -35,6 +36,8 @@ namespace PFire.Core.Protocol.Messages.Outbound
                 Usernames.Add(f.Username);
                 Nicks.Add(f.Nickname);
             });
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsList.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsList.cs
@@ -29,10 +29,10 @@ namespace PFire.Core.Protocol.Messages.Outbound
 
         public override async Task Process(IXFireClient context)
         {
-            var friends = await context.Server.Database.QueryFriends(_ownerUser);
+            var friends = context.Server.Database.QueryFriends(_ownerUser);
             friends.ForEach(f =>
             {
-                UserIds.Add(f.Id);
+                UserIds.Add(f.UserId);
                 Usernames.Add(f.Username);
                 Nicks.Add(f.Nickname);
             });

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsList.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsList.cs
@@ -27,17 +27,15 @@ namespace PFire.Core.Protocol.Messages.Outbound
         [XMessageField("nick")]
         public List<string> Nicks { get; }
 
-        public override Task Process(IXFireClient context)
+        public override async Task Process(IXFireClient context)
         {
-            var friends = context.Server.Database.QueryFriends(_ownerUser);
+            var friends = await context.Server.Database.QueryFriends(_ownerUser);
             friends.ForEach(f =>
             {
-                UserIds.Add(f.UserId);
+                UserIds.Add(f.Id);
                 Usernames.Add(f.Username);
                 Nicks.Add(f.Nickname);
             });
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsList.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsList.cs
@@ -29,7 +29,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
 
         public override async Task Process(IXFireClient context)
         {
-            var friends = context.Server.Database.QueryFriends(_ownerUser);
+            var friends = await context.Server.Database.QueryFriends(_ownerUser);
             friends.ForEach(f =>
             {
                 UserIds.Add(f.UserId);

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsSessionAssign.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsSessionAssign.cs
@@ -25,7 +25,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
         public List<Guid> SessionIds { get; }
 
         [XMessageField(0x0b)]
-        public byte Unknown { get; private set; }
+        public byte Unknown { get; set; }
 
         public override async Task Process(IXFireClient client)
         {

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsSessionAssign.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsSessionAssign.cs
@@ -27,19 +27,16 @@ namespace PFire.Core.Protocol.Messages.Outbound
         [XMessageField(0x0b)]
         public byte Unknown { get; private set; }
 
-        public override Task Process(IXFireClient client)
+        public override async Task Process(IXFireClient client)
         {
-            var friends = client.Server.Database.QueryFriends(_ownerUser);
-
+            var friends = await client.Server.Database.QueryFriends(_ownerUser);
             foreach (var friend in friends)
             {
                 var friendSession = client.Server.GetSession(friend);
 
-                UserIds.Add(friend.UserId);
-                SessionIds.Add(friendSession != null ? friendSession.SessionId : FriendIsOffLineSessionId);
+                UserIds.Add(friend.Id);
+                SessionIds.Add(friendSession?.SessionId ?? FriendIsOffLineSessionId);
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsSessionAssign.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsSessionAssign.cs
@@ -29,7 +29,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
 
         public override async Task Process(IXFireClient client)
         {
-            var friends = client.Server.Database.QueryFriends(_ownerUser);
+            var friends = await client.Server.Database.QueryFriends(_ownerUser);
             foreach (var friend in friends)
             {
                 var friendSession = client.Server.GetSession(friend);

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsSessionAssign.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsSessionAssign.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using PFire.Core.Session;
 using PFire.Infrastructure.Database;
 
@@ -26,7 +27,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
         [XMessageField(0x0b)]
         public byte Unknown { get; private set; }
 
-        public override void Process(IXFireClient client)
+        public override Task Process(IXFireClient client)
         {
             var friends = client.Server.Database.QueryFriends(_ownerUser);
 
@@ -37,6 +38,8 @@ namespace PFire.Core.Protocol.Messages.Outbound
                 UserIds.Add(friend.UserId);
                 SessionIds.Add(friendSession != null ? friendSession.SessionId : FriendIsOffLineSessionId);
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsSessionAssign.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsSessionAssign.cs
@@ -29,12 +29,12 @@ namespace PFire.Core.Protocol.Messages.Outbound
 
         public override async Task Process(IXFireClient client)
         {
-            var friends = await client.Server.Database.QueryFriends(_ownerUser);
+            var friends = client.Server.Database.QueryFriends(_ownerUser);
             foreach (var friend in friends)
             {
                 var friendSession = client.Server.GetSession(friend);
 
-                UserIds.Add(friend.Id);
+                UserIds.Add(friend.UserId);
                 SessionIds.Add(friendSession?.SessionId ?? FriendIsOffLineSessionId);
             }
         }

--- a/src/PFire.Core/Protocol/Messages/Outbound/Groups.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/Groups.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using PFire.Core.Session;
 
 namespace PFire.Core.Protocol.Messages.Outbound
@@ -13,10 +14,12 @@ namespace PFire.Core.Protocol.Messages.Outbound
         [XMessageField(0x1a)]
         public List<string> GroupNames { get; private set; }
 
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             GroupIds = new List<int>();
             GroupNames = new List<string>();
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/Groups.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/Groups.cs
@@ -9,10 +9,10 @@ namespace PFire.Core.Protocol.Messages.Outbound
         public Groups() : base(XFireMessageType.Groups) {}
 
         [XMessageField(0x19)]
-        public List<int> GroupIds { get; private set; }
+        public List<int> GroupIds { get; set; }
 
         [XMessageField(0x1a)]
-        public List<string> GroupNames { get; private set; }
+        public List<string> GroupNames { get; set; }
 
         public override Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Outbound/LoginChallenge.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/LoginChallenge.cs
@@ -1,4 +1,5 @@
-﻿using PFire.Core.Session;
+﻿using System.Threading.Tasks;
+using PFire.Core.Session;
 
 namespace PFire.Core.Protocol.Messages.Outbound
 {
@@ -9,9 +10,11 @@ namespace PFire.Core.Protocol.Messages.Outbound
         [XMessageField("salt")]
         public string Salt { get; private set; }
 
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             Salt = context.Salt;
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/LoginChallenge.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/LoginChallenge.cs
@@ -8,7 +8,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
         public LoginChallenge() : base(XFireMessageType.LoginChallenge) {}
 
         [XMessageField("salt")]
-        public string Salt { get; private set; }
+        public string Salt { get; set; }
 
         public override Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Outbound/LoginFailure.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/LoginFailure.cs
@@ -5,6 +5,6 @@
         public LoginFailure() : base(XFireMessageType.LoginFailure) {}
 
         [XMessageField("reason")]
-        public int Reason { get; private set; }
+        public int Reason { get; set; }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/LoginSuccess.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/LoginSuccess.cs
@@ -11,52 +11,52 @@ namespace PFire.Core.Protocol.Messages.Outbound
         public LoginSuccess() : base(XFireMessageType.LoginSuccess) {}
 
         [XMessageField("userid")]
-        public int UserId { get; private set; }
+        public int UserId { get; set; }
 
         [XMessageField("sid")]
-        public Guid SessionId { get; private set; }
+        public Guid SessionId { get; set; }
 
         [XMessageField("nick")]
-        public string Nickname { get; private set; }
+        public string Nickname { get; set; }
 
         [XMessageField("status")]
-        public int Status { get; private set; }
+        public int Status { get; set; }
 
         [XMessageField("dlset")]
-        public string DlSet { get; private set; }
+        public string DlSet { get; set; }
 
         [XMessageField("p2pset")]
-        public string P2PSet { get; private set; }
+        public string P2PSet { get; set; }
 
         [XMessageField("clntset")]
-        public string ClientSet { get; private set; }
+        public string ClientSet { get; set; }
 
         [XMessageField("minrect")]
-        public int MinRect { get; private set; }
+        public int MinRect { get; set; }
 
         [XMessageField("maxrect")]
-        public int MaxRect { get; private set; }
+        public int MaxRect { get; set; }
 
         [XMessageField("ctry")]
-        public int Country { get; private set; }
+        public int Country { get; set; }
 
         [XMessageField("n1")]
-        public int N1 { get; private set; }
+        public int N1 { get; set; }
 
         [XMessageField("n2")]
-        public int N2 { get; private set; }
+        public int N2 { get; set; }
 
         [XMessageField("n3")]
-        public int N3 { get; private set; }
+        public int N3 { get; set; }
 
         [XMessageField("pip")]
-        public int PublicIp { get; private set; }
+        public int PublicIp { get; set; }
 
         [XMessageField("salt")]
-        public string Salt { get; private set; }
+        public string Salt { get; set; }
 
         [XMessageField("reason")]
-        public string Reason { get; private set; }
+        public string Reason { get; set; }
 
         public override Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Outbound/LoginSuccess.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/LoginSuccess.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PFire.Core.Session;
 
@@ -57,7 +58,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
         [XMessageField("reason")]
         public string Reason { get; private set; }
 
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             UserId = context.User.UserId;
             SessionId = context.SessionId;
@@ -72,6 +73,8 @@ namespace PFire.Core.Protocol.Messages.Outbound
 
             context.Logger.LogDebug($"User {context.User.Username}[{context.User.UserId}] logged in successfully with session id {context.SessionId}");
             context.Logger.LogInformation($"User {context.User.Username} logged in");
+
+            return Task.CompletedTask;
         }
 
         private static string StripPortFromIPAddress(string address)

--- a/src/PFire.Core/Protocol/Messages/Outbound/ServerList.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/ServerList.cs
@@ -12,7 +12,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
         }
 
         [XMessageField("max")]
-        public int MaximumFavorites { get; private set; }
+        public int MaximumFavorites { get; set; }
 
         [XMessageField("gameid")]
         public List<int> GameIds { get; }

--- a/src/PFire.Core/Protocol/Messages/Outbound/UserLookupResult.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/UserLookupResult.cs
@@ -31,9 +31,10 @@ namespace PFire.Core.Protocol.Messages.Outbound
         [XMessageField("email")]
         public List<string> Emails { get; }
 
-        public override Task Process(IXFireClient context)
+        public override async Task Process(IXFireClient context)
         {
-            var usernames = context.Server.Database.QueryUsers(_queryByUsername).Select(a => a.Username).ToList();
+            var queryUsers = await context.Server.Database.QueryUsers(_queryByUsername);
+            var usernames = queryUsers.Select(a => a.Username).ToList();
 
             Usernames.AddRange(usernames);
 
@@ -43,8 +44,6 @@ namespace PFire.Core.Protocol.Messages.Outbound
             FirstNames.AddRange(unknowns);
             LastNames.AddRange(unknowns);
             Emails.AddRange(unknowns);
-            
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/UserLookupResult.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/UserLookupResult.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using PFire.Core.Session;
 
 namespace PFire.Core.Protocol.Messages.Outbound
@@ -30,7 +31,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
         [XMessageField("email")]
         public List<string> Emails { get; }
 
-        public override void Process(IXFireClient context)
+        public override Task Process(IXFireClient context)
         {
             var usernames = context.Server.Database.QueryUsers(_queryByUsername).Select(a => a.Username).ToList();
 
@@ -42,6 +43,8 @@ namespace PFire.Core.Protocol.Messages.Outbound
             FirstNames.AddRange(unknowns);
             LastNames.AddRange(unknowns);
             Emails.AddRange(unknowns);
+            
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/UserLookupResult.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/UserLookupResult.cs
@@ -33,7 +33,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
 
         public override async Task Process(IXFireClient context)
         {
-            var queryUsers = await context.Server.Database.QueryUsers(_queryByUsername);
+            var queryUsers = context.Server.Database.QueryUsers(_queryByUsername);
             var usernames = queryUsers.Select(a => a.Username).ToList();
 
             Usernames.AddRange(usernames);

--- a/src/PFire.Core/Protocol/Messages/Outbound/UserLookupResult.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/UserLookupResult.cs
@@ -33,7 +33,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
 
         public override async Task Process(IXFireClient context)
         {
-            var queryUsers = context.Server.Database.QueryUsers(_queryByUsername);
+            var queryUsers = await context.Server.Database.QueryUsers(_queryByUsername);
             var usernames = queryUsers.Select(a => a.Username).ToList();
 
             Usernames.AddRange(usernames);

--- a/src/PFire.Core/Protocol/Messages/XFireMessage.cs
+++ b/src/PFire.Core/Protocol/Messages/XFireMessage.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using PFire.Core.Session;
 
 namespace PFire.Core.Protocol.Messages
@@ -12,10 +13,12 @@ namespace PFire.Core.Protocol.Messages
 
         public XFireMessageType MessageTypeId { get; }
 
-        public virtual void Process(IXFireClient client)
+        public virtual Task Process(IXFireClient client)
         {
             // base implementation is to do nothing
             client.Logger.LogWarning($" *** Unimplemented processing for message type {MessageTypeId}");
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/PFire.Core/Session/XFireClient.cs
+++ b/src/PFire.Core/Session/XFireClient.cs
@@ -115,8 +115,8 @@ namespace PFire.Core.Session
 
             await _tcpClient.Client.SendAsync(payload, SocketFlags.None);
 
-            var username = User != null ? User.Username : "unknown";
-            var userId = User != null ? User.UserId : -1;
+            var username = User?.Username ?? "unknown";
+            var userId = User?.Id ?? -1;
 
             Logger.LogDebug($"Sent message[{username},{userId}]: {message}");
         }
@@ -238,8 +238,8 @@ namespace PFire.Core.Session
             {
                 var message = MessageSerializer.Deserialize(messageBuffer);
 
-                var username = User != null ? User.Username : "unknown";
-                var userId = User != null ? User.UserId : -1;
+                var username = User?.Username ?? "unknown";
+                var userId = User?.Id ?? -1;
 
                 Logger.LogDebug($"Recv message[{username},{userId}]: {message}");
 

--- a/src/PFire.Core/Session/XFireClient.cs
+++ b/src/PFire.Core/Session/XFireClient.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PFire.Core.Protocol;
 using PFire.Core.Protocol.Messages;
@@ -22,8 +23,8 @@ namespace PFire.Core.Session
         string Salt { get; }
         void Disconnect();
         void Dispose();
-        void SendAndProcessMessage(XFireMessage message);
-        void SendMessage(XFireMessage invite);
+        Task SendAndProcessMessage(XFireMessage message);
+        Task SendMessage(XFireMessage invite);
         void RemoveDuplicatedSessions(User user);
     }
 
@@ -91,13 +92,13 @@ namespace PFire.Core.Session
             _connected = false;
         }
 
-        public void SendAndProcessMessage(XFireMessage message)
+        public async Task SendAndProcessMessage(XFireMessage message)
         {
-            message.Process(this);
-            SendMessage(message);
+            await message.Process(this);
+            await SendMessage(message);
         }
 
-        public void SendMessage(XFireMessage message)
+        public async Task SendMessage(XFireMessage message)
         {
             if (Disposed)
             {
@@ -112,7 +113,7 @@ namespace PFire.Core.Session
 
             var payload = MessageSerializer.Serialize(message);
 
-            _tcpClient.Client.Send(payload);
+            await _tcpClient.Client.SendAsync(payload, SocketFlags.None);
 
             var username = User != null ? User.Username : "unknown";
             var userId = User != null ? User.UserId : -1;

--- a/src/PFire.Core/Session/XFireClient.cs
+++ b/src/PFire.Core/Session/XFireClient.cs
@@ -116,7 +116,7 @@ namespace PFire.Core.Session
             await _tcpClient.Client.SendAsync(payload, SocketFlags.None);
 
             var username = User?.Username ?? "unknown";
-            var userId = User?.Id ?? -1;
+            var userId = User?.UserId ?? -1;
 
             Logger.LogDebug($"Sent message[{username},{userId}]: {message}");
         }
@@ -239,7 +239,7 @@ namespace PFire.Core.Session
                 var message = MessageSerializer.Deserialize(messageBuffer);
 
                 var username = User?.Username ?? "unknown";
-                var userId = User?.Id ?? -1;
+                var userId = User?.UserId ?? -1;
 
                 Logger.LogDebug($"Recv message[{username},{userId}]: {message}");
 

--- a/src/PFire.Core/Session/XFireClientManager.cs
+++ b/src/PFire.Core/Session/XFireClientManager.cs
@@ -39,14 +39,9 @@ namespace PFire.Core.Session
 
         public IXFireClient GetSession(User user)
         {
-            var keyValuePair = _sessions.ToList().FirstOrDefault(a => a.Value.User == user);
+            var session = _sessions.ToList().Select(x => x.Value).FirstOrDefault(a => a.User == user);
 
-            if (!keyValuePair.Equals(default(KeyValuePair<Guid, IXFireClient>)))
-            {
-                return keyValuePair.Value;
-            }
-
-            return null;
+            return session == null ? null : GetSession(session.SessionId);
         }
 
         public void RemoveSession(IXFireClient session)


### PR DESCRIPTION
I'm separating this set of changes from the Entity Framework stuff because they can be, and it'll be easier to view the changes if they are.