### PR TITLE
Fix: Friend request wrong username

### DIFF
--- a/src/PFire.Console/appsettings.json
+++ b/src/PFire.Console/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "ConnectionStrings": {
-    "PFire": "pfiredb.sqlite"
+    "PFire": "Data Source=pfiredb.sqlite"
   },
   "Serilog": {
     "MinimumLevel": "Debug",

--- a/src/PFire.Core/Services/PFireDatabase.cs
+++ b/src/PFire.Core/Services/PFireDatabase.cs
@@ -209,9 +209,9 @@ namespace PFire.Core.Services
                                         .Where(x => x.Pending)
                                         .Select(x => new FriendRequestModel
                                         {
-                                            Id = x.Them.Id,
-                                            Username = x.Them.Username,
-                                            Nickname = x.Them.Nickname,
+                                            Id = x.Me.Id,
+                                            Username = x.Me.Username,
+                                            Nickname = x.Me.Nickname,
                                             Message = x.Message
                                         })
                                         .ToListAsync();

--- a/src/PFire.Core/Session/XFireClientManager.cs
+++ b/src/PFire.Core/Session/XFireClientManager.cs
@@ -38,7 +38,7 @@ namespace PFire.Core.Session
 
         public IXFireClient GetSession(UserModel user)
         {
-            var session = _sessions.ToList().Select(x => x.Value).FirstOrDefault(a => a.User.Id == user.Id);
+            var session = _sessions.ToList().Select(x => x.Value).FirstOrDefault(a => a.User?.Id == user?.Id);
 
             return session == null ? null : GetSession(session.SessionId);
         }

--- a/src/PFire.Core/Session/XFireClientManager.cs
+++ b/src/PFire.Core/Session/XFireClientManager.cs
@@ -38,7 +38,7 @@ namespace PFire.Core.Session
 
         public IXFireClient GetSession(UserModel user)
         {
-            var session = _sessions.ToList().Select(x => x.Value).FirstOrDefault(a => a.User?.Id == user?.Id);
+            var session = _sessions.ToList().Select(x => x.Value).FirstOrDefault(a => a.User?.Id == user.Id);
 
             return session == null ? null : GetSession(session.SessionId);
         }

--- a/src/PFire.Infrastructure/Services/DatabaseContext.cs
+++ b/src/PFire.Infrastructure/Services/DatabaseContext.cs
@@ -74,5 +74,8 @@ namespace PFire.Infrastructure.Services
             userEntity.Property(x => x.Salt).IsRequired();
             userEntity.Property(x => x.Nickname).HasMaxLength(1000);
         }
+
+        public DbSet<User> Users { get; set; }
+        public DbSet<Friend> Friends { get; set;}
     }
 }

--- a/src/PFire.Infrastructure/Services/DatabaseContext.cs
+++ b/src/PFire.Infrastructure/Services/DatabaseContext.cs
@@ -74,8 +74,5 @@ namespace PFire.Infrastructure.Services
             userEntity.Property(x => x.Salt).IsRequired();
             userEntity.Property(x => x.Nickname).HasMaxLength(1000);
         }
-
-        public DbSet<User> Users { get; set; }
-        public DbSet<Friend> Friends { get; set;}
     }
 }


### PR DESCRIPTION
Fix Bug:
The user saw only his own name in the notifications. The fix is that you see your future friend his name in the invite. The receiver his name is in the database them and the person who sent the request is me. So the receiver need to see me from the database. 