### PR TITLE
Packet 144 - Server PONG Response Implementation

### DIFF
--- a/src/PFire.Core/Protocol/Messages/Inbound/KeepAlive.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/KeepAlive.cs
@@ -11,7 +11,6 @@ namespace PFire.Core.Protocol.Messages.Inbound
 
         public async override Task Process(IXFireClient client)
         {
-            //Send a PONG response
             await client.SendAndProcessMessage(new ServerPong());
         }
     }

--- a/src/PFire.Core/Protocol/Messages/Inbound/KeepAlive.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/KeepAlive.cs
@@ -1,5 +1,7 @@
 ﻿using System.Threading.Tasks;
 using PFire.Core.Session;
+using PFire.Core.Protocol.Messages;
+using PFire.Core.Protocol.Messages.Outbound;
 
 namespace PFire.Core.Protocol.Messages.Inbound
 {
@@ -7,9 +9,10 @@ namespace PFire.Core.Protocol.Messages.Inbound
     {
         public KeepAlive() : base(XFireMessageType.KeepAlive) {}
 
-        public override Task Process(IXFireClient client)
+        public async override Task Process(IXFireClient client)
         {
-            return Task.CompletedTask;
+            //Send a PONG response
+            await client.SendAndProcessMessage(new ServerPong());
         }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/ServerPong.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/ServerPong.cs
@@ -18,7 +18,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
         public ServerPong() : base(XFireMessageType.ServerPong) { }
 
         [XMessageField("value")]
-        public int Value { get; set; }
+        public int Value { get; set; } = 0;
 
         public override Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Outbound/ServerPong.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/ServerPong.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using PFire.Core.Session;
+
+/// <summary>
+/// Packet 144 - Server to Client PONG response
+/// Attributes:
+///     value - Always zero, I suspect that they just need one attribute.
+/// </summary>
+
+namespace PFire.Core.Protocol.Messages.Outbound
+{
+    internal sealed class ServerPong : XFireMessage
+    {
+        public ServerPong() : base(XFireMessageType.ServerPong) { }
+
+        [XMessageField("value")]
+        public int Value { get; set; }
+
+        public override Task Process(IXFireClient context)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/PFire.Core/Protocol/Messages/XFireMessageType.cs
+++ b/src/PFire.Core/Protocol/Messages/XFireMessageType.cs
@@ -28,6 +28,7 @@
         FriendInvite = 138,
         ClientPreferences = 141,
         UserLookupResult = 143,
+        ServerPong = 144,
         ServerList = 148,
         Groups = 151,
         GroupsFriends = 152,


### PR DESCRIPTION
! This fixes the previous bug of the client timing out the server.

Description: When the Client sends a ping, the server will send back a PONG response immediately.

* This packet has been observed via the client disassembly as needing just a single attribute: 'value' which probably is a dummy attribute. I observed a similar attribute sent by the clientside packet KeepAlive (Packet 13). All captured packets wrote it as zero, I will do so also.

As such I have made the XFireMessage name into ServerPong.