### PR TITLE
Packets 4 and 135 - Game Information Packets

### DIFF
--- a/src/PFire.Core/Models/GameModel.cs
+++ b/src/PFire.Core/Models/GameModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PFire.Core.Models
+{
+    public class GameModel
+    {
+        public int GameID { get; set; }
+        public int GameIP { get; set; }
+        public int GamePort { get; set; }
+    }
+}

--- a/src/PFire.Core/Models/GameModel.cs
+++ b/src/PFire.Core/Models/GameModel.cs
@@ -8,8 +8,8 @@ namespace PFire.Core.Models
 {
     public class GameModel
     {
-        public int GameID { get; set; }
-        public int GameIP { get; set; }
-        public int GamePort { get; set; }
+        public int Id { get; set; }
+        public int Ip { get; set; }
+        public int Port { get; set; }
     }
 }

--- a/src/PFire.Core/Models/User.cs
+++ b/src/PFire.Core/Models/User.cs
@@ -6,8 +6,6 @@
         public string Username { get; set; }
         public string Password { get; set; }
         public string Nickname { get; set; }
-        public int GameID { get; set; }
-        public int GameIP { get; set; }
-        public int GamePort { get; set; }
+        public GameModel Game { get; set; } = new GameModel();
     }
 }

--- a/src/PFire.Core/Models/User.cs
+++ b/src/PFire.Core/Models/User.cs
@@ -6,5 +6,8 @@
         public string Username { get; set; }
         public string Password { get; set; }
         public string Nickname { get; set; }
+        public int GameID { get; set; }
+        public int GameIP { get; set; }
+        public int GamePort { get; set; }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/GameInformation.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/GameInformation.cs
@@ -1,4 +1,7 @@
-﻿namespace PFire.Core.Protocol.Messages.Inbound
+﻿using System.Threading.Tasks;
+using PFire.Core.Session;
+
+namespace PFire.Core.Protocol.Messages.Inbound
 {
     internal sealed class GameInformation : XFireMessage
     {
@@ -12,5 +15,13 @@
 
         [XMessageField("gport")]
         public int GamePort { get; set; }
+
+        public override async Task Process(IXFireClient context)
+        {
+            context.User.GameID = GameId;
+            context.User.GameIP = GameIP;
+            context.User.GamePort = GamePort;
+            await context.UpdateGameInfo();
+        }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/GameInformation.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/GameInformation.cs
@@ -20,9 +20,9 @@ namespace PFire.Core.Protocol.Messages.Inbound
 
         public override async Task Process(IXFireClient context)
         {
-            context.User.Game.GameID = GameId;
-            context.User.Game.GameIP = GameIP;
-            context.User.Game.GamePort = GamePort;
+            context.User.Game.Id = GameId;
+            context.User.Game.Ip = GameIP;
+            context.User.Game.Port = GamePort;
             await SendGameInfoToFriends(context);
         }
         public async Task SendGameInfoToFriends(IXFireClient context)

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsGameInfo.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsGameInfo.cs
@@ -38,7 +38,6 @@ namespace PFire.Core.Protocol.Messages.Outbound
 
         public override Task Process(IXFireClient client)
         {
-
             SessionIds.Add(client.Server.GetSession(_ownerUser).SessionId);
             GameID.Add(_ownerUser.GameID);
             GameIP.Add(_ownerUser.GameIP);

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsGameInfo.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsGameInfo.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using PFire.Core.Models;
+using PFire.Core.Session;
+
+namespace PFire.Core.Protocol.Messages.Outbound
+{
+    internal sealed class FriendsGamesInfo : XFireMessage
+    {
+        private readonly UserModel _ownerUser;
+
+        public FriendsGamesInfo(UserModel owner) : base(XFireMessageType.FriendsGameInfo)
+        {
+            _ownerUser = owner;
+            SessionIds = new List<Guid>();
+            GameID = new List<int>();
+            GameIP = new List<int>();
+            GamePort = new List<int>();
+
+        }
+
+        [XMessageField("sid")]
+        public List<Guid> SessionIds { get; set; }
+
+        [XMessageField("gameid")]
+        public List<int> GameID { get; set; }
+
+        [XMessageField("gip")]
+        public List<int> GameIP { get; set; }
+
+        [XMessageField("gport")]
+        public List<int> GamePort { get; set; }
+
+        public override Task Process(IXFireClient client)
+        {
+
+            SessionIds.Add(client.Server.GetSession(_ownerUser).SessionId);
+            GameID.Add(_ownerUser.GameID);
+            GameIP.Add(_ownerUser.GameIP);
+            GamePort.Add(_ownerUser.GamePort);
+            return Task.CompletedTask;
+        }
+
+    }
+}

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsGameInfo.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsGameInfo.cs
@@ -38,9 +38,9 @@ namespace PFire.Core.Protocol.Messages.Outbound
         public override Task Process(IXFireClient client)
         {
             SessionIds.Add(client.Server.GetSession(_ownerUser).SessionId);
-            GameID.Add(_ownerUser.Game.GameID);
-            GameIP.Add(_ownerUser.Game.GameIP);
-            GamePort.Add(_ownerUser.Game.GamePort);
+            GameID.Add(_ownerUser.Game.Id);
+            GameIP.Add(_ownerUser.Game.Ip);
+            GamePort.Add(_ownerUser.Game.Port);
             return Task.CompletedTask;
         }
 

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsGameInfo.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsGameInfo.cs
@@ -21,7 +21,6 @@ namespace PFire.Core.Protocol.Messages.Outbound
             GameID = new List<int>();
             GameIP = new List<int>();
             GamePort = new List<int>();
-
         }
 
         [XMessageField("sid")]

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsGameInfo.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsGameInfo.cs
@@ -38,9 +38,9 @@ namespace PFire.Core.Protocol.Messages.Outbound
         public override Task Process(IXFireClient client)
         {
             SessionIds.Add(client.Server.GetSession(_ownerUser).SessionId);
-            GameID.Add(_ownerUser.GameID);
-            GameIP.Add(_ownerUser.GameIP);
-            GamePort.Add(_ownerUser.GamePort);
+            GameID.Add(_ownerUser.Game.GameID);
+            GameIP.Add(_ownerUser.Game.GameIP);
+            GamePort.Add(_ownerUser.Game.GamePort);
             return Task.CompletedTask;
         }
 

--- a/src/PFire.Core/Protocol/Messages/XFireMessageType.cs
+++ b/src/PFire.Core/Protocol/Messages/XFireMessageType.cs
@@ -25,6 +25,7 @@
         FriendsList = 131,
         FriendsSessionAssign = 132,
         ServerChatMessage = 133,
+        FriendsGameInfo = 135,
         FriendInvite = 138,
         ClientPreferences = 141,
         UserLookupResult = 143,

--- a/src/PFire.Core/Session/XFireClient.cs
+++ b/src/PFire.Core/Session/XFireClient.cs
@@ -29,7 +29,6 @@ namespace PFire.Core.Session
         Task SendMessage(IMessage invite);
         Task StartSession(UserModel user);
         Task EndSession();
-        Task UpdateGameInfo();
     }
 
     internal sealed class XFireClient : Disposable, IXFireClient
@@ -127,19 +126,6 @@ namespace PFire.Core.Session
                 {
                     // TODO: Yuck - FriendsSessionAssign structure needs to be thought out differently as we aren't processing this one
                     await otherSession.SendMessage(FriendsSessionAssign.UserWentOffline(this.User));
-                }
-            }
-        }
-
-        public async Task UpdateGameInfo()
-        {
-            var friends = await Server.Database.QueryFriends(User);
-            foreach (var friend in friends)
-            {
-                var otherSession = Server.GetSession(friend);
-                if (otherSession != null)
-                {
-                    await otherSession.SendAndProcessMessage(new FriendsGamesInfo(this.User));
                 }
             }
         }

--- a/src/PFire.Core/Session/XFireClient.cs
+++ b/src/PFire.Core/Session/XFireClient.cs
@@ -29,6 +29,7 @@ namespace PFire.Core.Session
         Task SendMessage(IMessage invite);
         Task StartSession(UserModel user);
         Task EndSession();
+        Task UpdateGameInfo();
     }
 
     internal sealed class XFireClient : Disposable, IXFireClient
@@ -126,6 +127,19 @@ namespace PFire.Core.Session
                 {
                     // TODO: Yuck - FriendsSessionAssign structure needs to be thought out differently as we aren't processing this one
                     await otherSession.SendMessage(FriendsSessionAssign.UserWentOffline(this.User));
+                }
+            }
+        }
+
+        public async Task UpdateGameInfo()
+        {
+            var friends = await Server.Database.QueryFriends(User);
+            foreach (var friend in friends)
+            {
+                var otherSession = Server.GetSession(friend);
+                if (otherSession != null)
+                {
+                    await otherSession.SendAndProcessMessage(new FriendsGamesInfo(this.User));
                 }
             }
         }


### PR DESCRIPTION
(This is a preliminary addition. Game IPs/Ports SHOULD work, but I haven't tested it yet.)

* This packet sends a game id, as dictated by the client, if the other client doesn't have the id, it won't show it.

Added UpdateGameInfo to XFireClient Class and 135 to the list of Message Types.