### PR TITLE
0x02 Attribute is possibly unsigned. Made all Signed Ints are now Unsigned.

### DIFF
--- a/src/PFire.Core/Models/FriendRequestModel.cs
+++ b/src/PFire.Core/Models/FriendRequestModel.cs
@@ -2,7 +2,7 @@
 {
     public class FriendRequestModel
     {
-        public int Id { get; set; }
+        public uint Id { get; set; }
         public string Username { get; set; }
         public string Nickname { get; set; }
         public string Message { get; set; }

--- a/src/PFire.Core/Models/GameModel.cs
+++ b/src/PFire.Core/Models/GameModel.cs
@@ -8,8 +8,8 @@ namespace PFire.Core.Models
 {
     public class GameModel
     {
-        public int Id { get; set; }
-        public int Ip { get; set; }
-        public int Port { get; set; }
+        public uint Id { get; set; }
+        public uint Ip { get; set; }
+        public uint Port { get; set; }
     }
 }

--- a/src/PFire.Core/Models/User.cs
+++ b/src/PFire.Core/Models/User.cs
@@ -2,7 +2,7 @@
 {
     public class UserModel
     {
-        public int Id { get; set; }
+        public uint Id { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
         public string Nickname { get; set; }

--- a/src/PFire.Core/Protocol/Messages/Bidirectional/ChatContent.cs
+++ b/src/PFire.Core/Protocol/Messages/Bidirectional/ChatContent.cs
@@ -5,7 +5,7 @@
         public ChatContent() : base(XFireMessageType.ServerChatMessage) {}
 
         [XMessageField("imindex")]
-        public int MessageOrderIndex { get; set; }
+        public uint MessageOrderIndex { get; set; }
 
         [XMessageField("im")]
         public string MessageContent { get; set; }

--- a/src/PFire.Core/Protocol/Messages/Bidirectional/ChatMessage.cs
+++ b/src/PFire.Core/Protocol/Messages/Bidirectional/ChatMessage.cs
@@ -79,7 +79,7 @@ namespace PFire.Core.Protocol.Messages.Bidirectional
                 MessagePayload = new Dictionary<string, dynamic>
                 {
                     {"msgtyp", (byte)ChatMessageType.Acknowledgement},
-                    {"imindex", (int)MessagePayload["imindex"]}
+                    {"imindex", (uint)MessagePayload["imindex"]}
                 }
             };
         }

--- a/src/PFire.Core/Protocol/Messages/Bidirectional/ChatTypingNotification.cs
+++ b/src/PFire.Core/Protocol/Messages/Bidirectional/ChatTypingNotification.cs
@@ -8,9 +8,9 @@
         public ChatTypingNotification() : base(XFireMessageType.ServerChatMessage) {}
 
         [XMessageField("imindex")]
-        public int OrderIndex { get; set; }
+        public uint OrderIndex { get; set; }
 
         [XMessageField("typing")]
-        public int Typing { get; set; }
+        public uint Typing { get; set; }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Inbound/ClientVersion.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/ClientVersion.cs
@@ -9,10 +9,10 @@ namespace PFire.Core.Protocol.Messages.Inbound
         public ClientVersion() : base(XFireMessageType.ClientVersion) {}
 
         [XMessageField("version")]
-        public int Version { get; set; }
+        public uint Version { get; set; }
 
         [XMessageField("major_version")]
-        public int MajorVersion { get; set; }
+        public uint MajorVersion { get; set; }
 
         public override async Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Inbound/ConnectionInformation.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/ConnectionInformation.cs
@@ -10,19 +10,19 @@ namespace PFire.Core.Protocol.Messages.Inbound
         public ConnectionInformation() : base(XFireMessageType.ConnectionInformation) {}
 
         [XMessageField("conn")]
-        public int Connection { get; set; }
+        public uint Connection { get; set; }
 
         [XMessageField("nat")]
-        public int Nat { get; set; }
+        public uint Nat { get; set; }
 
         [XMessageField("naterr")]
-        public int NatError { get; set; }
+        public uint NatError { get; set; }
 
         [XMessageField("sec")]
-        public int Sec { get; set; }
+        public uint Sec { get; set; }
 
         [XMessageField("clientip")]
-        public int ClientIp { get; set; }
+        public uint ClientIp { get; set; }
 
         [XMessageField("upnpinfo")]
         public string UpnpInfo { get; set; }

--- a/src/PFire.Core/Protocol/Messages/Inbound/FriendRemoval.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/FriendRemoval.cs
@@ -9,7 +9,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
         public FriendRemoval() : base(XFireMessageType.FriendRemoval) { }
 
         [XMessageField("userid")]
-        public int UserId { get; set; }
+        public uint UserId { get; set; }
 
         public override async Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Inbound/GameInformation.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/GameInformation.cs
@@ -10,13 +10,13 @@ namespace PFire.Core.Protocol.Messages.Inbound
         public GameInformation() : base(XFireMessageType.GameInformation) {}
 
         [XMessageField("gameid")]
-        public int GameId { get; set; }
+        public uint GameId { get; set; }
 
         [XMessageField("gip")]
-        public int GameIP { get; set; }
+        public uint GameIP { get; set; }
 
         [XMessageField("gport")]
-        public int GamePort { get; set; }
+        public uint GamePort { get; set; }
 
         public override async Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Inbound/LoginRequest.cs
+++ b/src/PFire.Core/Protocol/Messages/Inbound/LoginRequest.cs
@@ -15,7 +15,7 @@ namespace PFire.Core.Protocol.Messages.Inbound
         public string Password { get; set; }
 
         [XMessageField("flags")]
-        public int Flags { get; set; }
+        public uint Flags { get; set; }
 
         public override async Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/Messages/Outbound/ChatRooms.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/ChatRooms.cs
@@ -6,10 +6,10 @@ namespace PFire.Core.Protocol.Messages.Outbound
     {
         public ChatRooms() : base(XFireMessageType.ChatRooms)
         {
-            ChatIds = new List<int>();
+            ChatIds = new List<uint>();
         }
 
         [XMessageField(0x04)]
-        public List<int> ChatIds { get; }
+        public List<uint> ChatIds { get; }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendRemoved.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendRemoved.cs
@@ -5,12 +5,12 @@ namespace PFire.Core.Protocol.Messages.Outbound
 {
     internal sealed class FriendRemoved : XFireMessage
     {
-        public FriendRemoved(int userId) : base(XFireMessageType.FriendRemoved)
+        public FriendRemoved(uint userId) : base(XFireMessageType.FriendRemoved)
         {
             UserId = userId;
         }
 
         [XMessageField("userid")]
-        public int UserId { get; set; }
+        public uint UserId { get; set; }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsGameInfo.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsGameInfo.cs
@@ -18,22 +18,22 @@ namespace PFire.Core.Protocol.Messages.Outbound
         {
             _ownerUser = owner;
             SessionIds = new List<Guid>();
-            GameID = new List<int>();
-            GameIP = new List<int>();
-            GamePort = new List<int>();
+            GameID = new List<uint>();
+            GameIP = new List<uint>();
+            GamePort = new List<uint>();
         }
 
         [XMessageField("sid")]
         public List<Guid> SessionIds { get; set; }
 
         [XMessageField("gameid")]
-        public List<int> GameID { get; set; }
+        public List<uint> GameID { get; set; }
 
         [XMessageField("gip")]
-        public List<int> GameIP { get; set; }
+        public List<uint> GameIP { get; set; }
 
         [XMessageField("gport")]
-        public List<int> GamePort { get; set; }
+        public List<uint> GamePort { get; set; }
 
         public override Task Process(IXFireClient client)
         {

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsList.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsList.cs
@@ -13,13 +13,13 @@ namespace PFire.Core.Protocol.Messages.Outbound
         {
             _ownerUser = owner;
 
-            UserIds = new List<int>();
+            UserIds = new List<uint>();
             Usernames = new List<string>();
             Nicks = new List<string>();
         }
 
         [XMessageField("userid")]
-        public List<int> UserIds { get; }
+        public List<uint> UserIds { get; }
 
         [XMessageField("friends")]
         public List<string> Usernames { get; }

--- a/src/PFire.Core/Protocol/Messages/Outbound/FriendsSessionAssign.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/FriendsSessionAssign.cs
@@ -15,12 +15,12 @@ namespace PFire.Core.Protocol.Messages.Outbound
         public FriendsSessionAssign(UserModel owner) : base(XFireMessageType.FriendsSessionAssign)
         {
             _ownerUser = owner;
-            UserIds = new List<int>();
+            UserIds = new List<uint>();
             SessionIds = new List<Guid>();
         }
 
         [XMessageField("userid")] 
-        public List<int> UserIds { get; }
+        public List<uint> UserIds { get; }
 
         [XMessageField("sid")] 
         public List<Guid> SessionIds { get; }

--- a/src/PFire.Core/Protocol/Messages/Outbound/Groups.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/Groups.cs
@@ -9,14 +9,14 @@ namespace PFire.Core.Protocol.Messages.Outbound
         public Groups() : base(XFireMessageType.Groups) {}
 
         [XMessageField(0x19)]
-        public List<int> GroupIds { get; set; }
+        public List<uint> GroupIds { get; set; }
 
         [XMessageField(0x1a)]
         public List<string> GroupNames { get; set; }
 
         public override Task Process(IXFireClient context)
         {
-            GroupIds = new List<int>();
+            GroupIds = new List<uint>();
             GroupNames = new List<string>();
 
             return Task.CompletedTask;

--- a/src/PFire.Core/Protocol/Messages/Outbound/GroupsFriends.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/GroupsFriends.cs
@@ -6,14 +6,14 @@ namespace PFire.Core.Protocol.Messages.Outbound
     {
         public GroupsFriends() : base(XFireMessageType.GroupsFriends)
         {
-            UserIds = new List<int>();
-            GroupIds = new List<int>();
+            UserIds = new List<uint>();
+            GroupIds = new List<uint>();
         }
 
         [XMessageField(0x01)]
-        public List<int> UserIds { get; }
+        public List<uint> UserIds { get; }
 
         [XMessageField(0x19)]
-        public List<int> GroupIds { get; }
+        public List<uint> GroupIds { get; }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/LoginFailure.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/LoginFailure.cs
@@ -5,6 +5,6 @@
         public LoginFailure() : base(XFireMessageType.LoginFailure) {}
 
         [XMessageField("reason")]
-        public int Reason { get; set; }
+        public uint Reason { get; set; }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/LoginSuccess.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/LoginSuccess.cs
@@ -11,7 +11,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
         public LoginSuccess() : base(XFireMessageType.LoginSuccess) {}
 
         [XMessageField("userid")]
-        public int UserId { get; set; }
+        public uint UserId { get; set; }
 
         [XMessageField("sid")]
         public Guid SessionId { get; set; }
@@ -20,7 +20,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
         public string Nickname { get; set; }
 
         [XMessageField("status")]
-        public int Status { get; set; }
+        public uint Status { get; set; }
 
         [XMessageField("dlset")]
         public string DlSet { get; set; }
@@ -32,25 +32,25 @@ namespace PFire.Core.Protocol.Messages.Outbound
         public string ClientSet { get; set; }
 
         [XMessageField("minrect")]
-        public int MinRect { get; set; }
+        public uint MinRect { get; set; }
 
         [XMessageField("maxrect")]
-        public int MaxRect { get; set; }
+        public uint MaxRect { get; set; }
 
         [XMessageField("ctry")]
-        public int Country { get; set; }
+        public uint Country { get; set; }
 
         [XMessageField("n1")]
-        public int N1 { get; set; }
+        public uint N1 { get; set; }
 
         [XMessageField("n2")]
-        public int N2 { get; set; }
+        public uint N2 { get; set; }
 
         [XMessageField("n3")]
-        public int N3 { get; set; }
+        public uint N3 { get; set; }
 
         [XMessageField("pip")]
-        public int PublicIp { get; set; }
+        public uint PublicIp { get; set; }
 
         [XMessageField("salt")]
         public string Salt { get; set; }
@@ -67,7 +67,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
             MinRect = 1;
             MaxRect = 164867;
             var ipAddress = StripPortFromIpAddress(context.RemoteEndPoint.ToString());
-            PublicIp = BitConverter.ToInt32(IPAddress.Parse(ipAddress).GetAddressBytes(), 0);
+            PublicIp = BitConverter.ToUInt32(IPAddress.Parse(ipAddress).GetAddressBytes(), 0);
             Salt = context.Salt;
             Reason = "Mq_P8Ad3aMEUvFinw0ceu6FITnZTWXxg46XU8xHW";
 

--- a/src/PFire.Core/Protocol/Messages/Outbound/ServerList.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/ServerList.cs
@@ -6,21 +6,21 @@ namespace PFire.Core.Protocol.Messages.Outbound
     {
         public ServerList() : base(XFireMessageType.ServerList)
         {
-            GameIds = new List<int>();
-            GameIPs = new List<int>();
-            GamePorts = new List<int>();
+            GameIds = new List<uint>();
+            GameIPs = new List<uint>();
+            GamePorts = new List<uint>();
         }
 
         [XMessageField("max")]
-        public int MaximumFavorites { get; set; }
+        public uint MaximumFavorites { get; set; }
 
         [XMessageField("gameid")]
-        public List<int> GameIds { get; }
+        public List<uint> GameIds { get; }
 
         [XMessageField("gip")]
-        public List<int> GameIPs { get; }
+        public List<uint> GameIPs { get; }
 
         [XMessageField("gport")]
-        public List<int> GamePorts { get; }
+        public List<uint> GamePorts { get; }
     }
 }

--- a/src/PFire.Core/Protocol/Messages/Outbound/ServerPong.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/ServerPong.cs
@@ -18,7 +18,7 @@ namespace PFire.Core.Protocol.Messages.Outbound
         public ServerPong() : base(XFireMessageType.ServerPong) { }
 
         [XMessageField("value")]
-        public int Value { get; set; } = 0;
+        public uint Value { get; set; } = 0;
 
         public override Task Process(IXFireClient context)
         {

--- a/src/PFire.Core/Protocol/XFireAttributeFactory.cs
+++ b/src/PFire.Core/Protocol/XFireAttributeFactory.cs
@@ -16,7 +16,8 @@ namespace PFire.Core.Protocol
         private XFireAttributeFactory()
         {
             Add(new StringAttribute());
-            Add(new Int32Attribute());
+            //Add(new Int32Attribute());
+            Add(new UInt32Attribute());
             Add(new SessionIdAttribute());
             Add(new ListAttribute());
             Add(new DidAttribute());

--- a/src/PFire.Core/Protocol/XFireAttributes/MessageAttribute.cs
+++ b/src/PFire.Core/Protocol/XFireAttributes/MessageAttribute.cs
@@ -9,13 +9,13 @@ namespace PFire.Core.Protocol.XFireAttributes
 {
     public class MessageAttribute : XFireAttribute
     {
-        private static readonly Dictionary<int, IMessage> MESSAGE_TYPES = new Dictionary<int, IMessage>
+        private static readonly Dictionary<uint, IMessage> MESSAGE_TYPES = new Dictionary<uint, IMessage>
         {
             { 0, new ChatMessage() },
             { 1, new ChatAcknowledgement() }
         };
 
-        private IMessage CreateMessage(short type)
+        private IMessage CreateMessage(uint type)
         {
             if(!MESSAGE_TYPES.ContainsKey(type))
             {

--- a/src/PFire.Core/Protocol/XFireAttributes/UInt32Attribute.cs
+++ b/src/PFire.Core/Protocol/XFireAttributes/UInt32Attribute.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.IO;
+
+namespace PFire.Core.Protocol.XFireAttributes
+{
+    public class UInt32Attribute : XFireAttribute
+    {
+        public override byte AttributeTypeId => 0x02;
+
+        public override Type AttributeType => typeof(uint);
+
+        public override dynamic ReadValue(BinaryReader reader)
+        {
+            return reader.ReadUInt32();
+        }
+
+        public override void WriteValue(BinaryWriter writer, dynamic data)
+        {
+            writer.Write((uint)data);
+        }
+    }
+}

--- a/src/PFire.Core/Services/PFireDatabase.cs
+++ b/src/PFire.Core/Services/PFireDatabase.cs
@@ -17,7 +17,7 @@ namespace PFire.Core.Services
         Task InsertMutualFriend(UserModel me, UserModel them);
         Task InsertFriendRequest(UserModel me, UserModel them, string message);
         Task<UserModel> QueryUser(string username);
-        Task<UserModel> QueryUser(int userId);
+        Task<UserModel> QueryUser(uint userId);
         Task<List<UserModel>> QueryUsers(string username);
         Task<List<UserModel>> QueryFriends(UserModel user);
         Task<List<FriendRequestModel>> QueryPendingFriendRequestsSelf(UserModel user);
@@ -168,7 +168,7 @@ namespace PFire.Core.Services
                                         .FirstOrDefaultAsync();
         }
 
-        public async Task<UserModel> QueryUser(int userId)
+        public async Task<UserModel> QueryUser(uint userId)
         {
             using var scope = _serviceProvider.CreateScope();
             var databaseContext = scope.ServiceProvider.GetRequiredService<IDatabaseContext>();

--- a/src/PFire.Core/Util/LoggerExtensions.cs
+++ b/src/PFire.Core/Util/LoggerExtensions.cs
@@ -17,7 +17,7 @@ namespace PFire.Core.Util
             }
 
             var username = user?.Username ?? "unknown";
-            var userId = user?.Id ?? -1;
+            var userId = user?.Id ?? 0;
             
             logger.LogDebug($"Sent message[{username},{userId}]: {message}");
         }

--- a/src/PFire.Infrastructure/Entities/Friend.cs
+++ b/src/PFire.Infrastructure/Entities/Friend.cs
@@ -5,10 +5,10 @@ namespace PFire.Infrastructure.Entities
 {
     public class Friend : Entity
     {
-        public int MeId { get; set; }
+        public uint MeId { get; set; }
         public User Me { get; set; }
 
-        public int ThemId { get; set; }
+        public uint ThemId { get; set; }
         public User Them { get; set; }
 
         public string Message { get; set; }

--- a/src/PFire.Infrastructure/Entities/User.cs
+++ b/src/PFire.Infrastructure/Entities/User.cs
@@ -6,7 +6,7 @@ namespace PFire.Infrastructure.Entities
 {
     public class User : Entity
     {
-        public int Id { get; set; }
+        public uint Id { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
         public string Salt { get; set; }


### PR DESCRIPTION
I suspect that 0x02 int32 is unsigned. 
Reasons to believe:
* The client and server will send IP addresses as hex under 0x02, which sometimes can and often exceed the signed limit of 2147483647.
* Documentation and code from the xfire pidgin plugin treats the 0x02 attribute type as a uint32.
* Documentation and code from the xfire wireshark plugin (same author) treats the 0x02 attribute type as a uint32.

Reasons to reject:
* In all of the documentation found, it is never explicitly expressed one way or the other.
* The disassembly is ambiguous, I see debug prints that say GetInt32() and GetHashValueInt32(), but I cannot confirm nor deny if its looking for uint32 or int32.

pFire:
Preliminary testing has shown for this to connect and operate like normal. More testing is needed to make it gold.

Note:
* Logging had a -1, it is now 0, I don't know if that impacts anything.