### PR TITLE
Packet 169 - System Broadcast

### DIFF
--- a/src/PFire.Core/Protocol/Messages/Outbound/SystemBroadcastMessage.cs
+++ b/src/PFire.Core/Protocol/Messages/Outbound/SystemBroadcastMessage.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PFire.Core.Protocol.Messages.Outbound
+{
+    internal sealed class SystemBroadcastMessage : XFireMessage
+    {
+        public SystemBroadcastMessage(string message) : base(XFireMessageType.SystemBroadcast)
+        {
+            Message = message;
+        }
+
+        // Not entirely sure what this does. I looked at decompiled code and it seems to make it
+        // skip over reading a string if set to zero or something. However even when set to zero
+        // it still displays.
+        [XMessageField(0x34)]
+        public int Unk { get; set; }
+
+        [XMessageField(0x2E)]
+        public string Message { get; set; }
+    }
+}

--- a/src/PFire.Core/Protocol/Messages/XFireMessageType.cs
+++ b/src/PFire.Core/Protocol/Messages/XFireMessageType.cs
@@ -39,6 +39,7 @@
         GroupsFriends = 152,
         FriendStatusChange = 154,
         ChatRooms = 155,
+        SystemBroadcast = 169,
 
         Did = 400
     }


### PR DESCRIPTION
This packet is sent from the server to send a broadcast to all logged in clients.

It features two attributes: An unknown int and a message.

As noted in the comments, I am not sure what the int sent does. I looked at decompiled code and it seems to make it skip over reading a string if set to zero or something. However even when set to zero it still displays.